### PR TITLE
Add documentation on member activity endpoint

### DIFF
--- a/source/includes/_authenticated_api_members.md
+++ b/source/includes/_authenticated_api_members.md
@@ -50,7 +50,9 @@ Find a member by id. Member ids can be discovered via a call to the lookup API.
 }
 ```
 
-Get information about a member's activity on the platform.
+Get information about a member's activity on the platform. This can be useful if you're building a member dashboard that includes information from ControlShift and other toolsets.
+
+The member activity report includes basic biographical information as well as petitions created or signed, events hosted or attended, group memberships, forum posts, partnership subscriptions, and unsubscribe history.
 
 `GET /api/v1/members/123/activity`
 

--- a/source/includes/_authenticated_api_members.md
+++ b/source/includes/_authenticated_api_members.md
@@ -27,6 +27,35 @@ Find a member by id. Member ids can be discovered via a call to the lookup API.
 `GET /api/v1/members/123`
 
 
+
+### Activity
+```json
+{
+  "first_name": "Jane",
+  "last_name": "Doe",
+  "phone_number: "555-555-5555",
+  "created_at": "2015-06-01T15:37:47Z",
+
+  "signatures": [
+    {
+      "email": "jane.doe@example.com",
+      "petition": {
+        "slug": "save-the-whales"
+      }
+      ...
+    }
+    ...
+  ]
+  ...
+}
+```
+
+Get information about a member's activity on the platform.
+
+`GET /api/v1/members/123/activity`
+
+
+
 ### Destroy
 ```json
 {


### PR DESCRIPTION
This adds documentation on the new member activity authenticated API endpoint, which is added in https://github.com/controlshift/agra/pull/1403