### PR TITLE
Expand documentation for authenticated members#show endpoint

### DIFF
--- a/source/includes/_authenticated_api_members.md
+++ b/source/includes/_authenticated_api_members.md
@@ -21,8 +21,35 @@ Find a member by email address. Once you have obtained a member id you can use t
 
 
 ### Show
+```json
+{
+  "member": {
+    "id": 123,
+    "email": "foo@bar.com",
+    "created_at": "2015-06-01T15:37:47Z",
+    "updated_at": "2017-07-01T11:23:45Z",
+    "external_id": "abc123",
+
+    "data_processing_consent": {
+      "consented_to_latest_version": false,
+
+      "most_recent_consent_from_member": {
+        "consented_at": "2018-01-01T04:00Z",
+
+        "consent_content_version": {
+          "id": "25",
+          "external_id": "def456",
+          "created_at": "2017-12-31T23:59Z"
+        }
+      }
+    }
+  }
+}
+```
 
 Find a member by id. Member ids can be discovered via a call to the lookup API. 
+
+The `data_processing_consent` block is only present when the data processing consent feature is enabled.
 
 `GET /api/v1/members/123`
 

--- a/source/includes/_authenticated_api_members.md
+++ b/source/includes/_authenticated_api_members.md
@@ -3,24 +3,8 @@
 The platform transparently creates a member record for any email address that creates a user account, signs a petition, or attends an event. Members are unique by email address, and all 
 platform activity is tracked by member id.  
 
-### Lookup
-```json
-{
-  "member": {
-    "id": 123,
-    "email": "foo@bar.com",
-    ...
-  }
-}
-```
+> GET response body for Lookup or Show
 
-Find a member by email address. Once you have obtained a member id you can use this identifier in other API calls. 
-
-`GET /api/v1/members/lookup?email=foo@bar.com`
-
-
-
-### Show
 ```json
 {
   "member": {
@@ -47,7 +31,17 @@ Find a member by email address. Once you have obtained a member id you can use t
 }
 ```
 
-Find a member by id. Member ids can be discovered via a call to the lookup API. 
+### Lookup
+
+Find a member by email address. Once you have obtained a member id you can use this identifier in other API calls. 
+
+`GET /api/v1/members/lookup?email=foo@bar.com`
+
+
+
+### Show
+
+Find a member by id.
 
 The `data_processing_consent` block is only present when the data processing consent feature is enabled.
 
@@ -56,6 +50,9 @@ The `data_processing_consent` block is only present when the data processing con
 
 
 ### Activity
+
+> GET response body for Activity
+
 ```json
 {
   "first_name": "Jane",
@@ -86,6 +83,9 @@ The member activity report includes basic biographical information as well as pe
 
 
 ### Destroy
+
+> DELETE response body for Destroy
+
 ```json
 {
   "member": {
@@ -107,6 +107,9 @@ Ownership of Petitions and Events created by the deleted member will be re-assig
 
 
 ### Unsubscribe
+
+> POST response body for Unsubscribe
+
 ```json
 {
   "member": {


### PR DESCRIPTION
This updates the Authenticated REST API documentation for the `/api/v1/members/123` endpoint, adding a full JSON response example that includes the data processing consent block. It also adds labels to clarify which sections of the example sidebar belong with which documentation.
![docs](https://user-images.githubusercontent.com/1977279/36435650-34bce7ec-1630-11e8-9d56-000a5b060a84.png)
