### PR TITLE
Add documentation for new partnership petitions JSON endpoint

### DIFF
--- a/source/includes/_json_partnership_petitions.md
+++ b/source/includes/_json_partnership_petitions.md
@@ -1,0 +1,150 @@
+## List petitions in a partnership
+
+```js
+$(document).ready(function(){
+  $.ajax({
+    url: 'https://demo.controlshiftlabs.com/partnerships/our-awesome-partner/petitions.json',
+    dataType: 'jsonp',
+  })
+  .done(function(data) {
+    console.log(data);
+  });
+});
+```
+
+> The above code would return petitions data from the partnership with the slug `our-awesome-partner`.  The JSON would be structured like this:
+
+```json
+{
+  "current_page": 1,
+  "total_pages": 1,
+  "previous_page": null,
+  "next_page": null,
+  "name": "Our Awesome Partner",
+  "results": [{
+    "slug": "apple-stop-your-comic-sans-snobbery",
+    "title": "Apple: Stop your Comic Sans snobbery",
+    "url": "http://demo.controlshiftlabs.com/petitions/apple-stop-your-comic-sans-snobbery",
+    "admin_status": "good",
+    "image_url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/24551/hero/helveticacomicsans.gif?1398764339",
+    "additional_image_sizes_url": [{
+      "style": "form",
+      "url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/24551/form/helveticacomicsans.gif?1398764339"
+    }, {
+      "style": "large",
+      "url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/24551/large/helveticacomicsans.gif?1398764339"
+    }, {
+      "style": "open_graph",
+      "url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/24551/open_graph/helveticacomicsans.gif?1398764339"
+    }, {
+      "style": "original",
+      "url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/24551/original/helveticacomicsans.gif?1398764339"
+    }],
+    "who": "Tim Cook, CEO Apple",
+    "what": "Use Comic Sans for the default font on the iPhone 6.",
+    "goal": 100,
+    "signature_count": 7,
+    "creator_name": "John Wood",
+    "created_at": "2014-04-29T05:35:47Z",
+    "updated_at": "2016-01-06T11:02:17Z",
+    "why": "Apple occupy a key position in the hearts of typeface poseurs everywhere. If they were to make a bold step and switch to using the people's font, Comic Sans on the new iPhone, this would cause mass..."
+  }, {
+    "slug": "clean-up-the-himalayas",
+    "title": "Clean up the Himalayas",
+    "url": "http://demo.controlshiftlabs.com/petitions/clean-up-the-himalayas",
+    "admin_status": "good",
+    "image_url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/6359/hero/gorak_shep_thumb.jpg?1431734031",
+    "additional_image_sizes_url": [{
+      "style": "form",
+      "url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/6359/form/gorak_shep_thumb.jpg?1431734031"
+    }, {
+      "style": "large",
+      "url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/6359/large/gorak_shep_thumb.jpg?1431734031"
+    }, {
+      "style": "open_graph",
+      "url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/6359/open_graph/gorak_shep_thumb.jpg?1431734031"
+    }, {
+      "style": "original",
+      "url": "https://d8s293fyljwh4.cloudfront.net/petitions/images/6359/original/gorak_shep_thumb.jpg?1431734031"
+    }],
+    "who": "Nepal Ghurung",
+    "what": "Clean up the Khumbu region.",
+    "goal": 100,
+    "signature_count": 1,
+    "creator_name": "Grant Cox",
+    "created_at": "2013-06-03T17:13:41Z",
+    "updated_at": "2015-07-17T15:11:48Z",
+    "why": "It's quite dirty, and I don't like it.",
+    "location": {
+      "query": "Nepal",
+      "latitude": "28.394857",
+      "longitude": "84.124008",
+      "street": "",
+      "postal_code": "",
+      "country": "NP",
+      "region": "",
+      "street_number": "",
+      "venue": "Nepal",
+      "created_at": "2013-06-03T17:13:41Z"
+    }
+  }]
+}
+
+```
+
+This retrieves a paginated list of petitions in a partnership.
+
+### HTTP Request
+
+`GET https://demo.controlshiftlabs.com/partnerships/<partnership slug>/petitions.json`
+
+### Query Parameters
+
+Parameter | Default | Description
+--------- | ------- | -----------
+partnership slug | null | string - required - submitted as a part of the endpoint path, not as a separate URL parameter
+page | 1 | integer - optional - The page number of results for the specified partnership. Minimum of 1.
+
+### Working Example
+
+View and edit a working example on codepen.io:
+
+<div class="js-codepen-data hidden"  data-title="ControlShift Labs: List of Petitions in a Partnership Example">
+  <div class="codepen-html">
+    <h1>Petitions in partnership "<span id="name"></span>"</h1>
+    <div id="petitions">
+    </div>
+  </div>
+  <pre class="codepen-js">
+    $(document).ready(function(){
+      $.ajax({
+        url: 'https://demo.controlshiftlabs.com/partnership/rtm-roundtable-of-mice/petitions.json',
+        dataType: 'jsonp',
+      })
+      .done(function(data) {
+        // Populate global partnership data
+        $('#name').text(data.name);
+
+        // Populate petitions data
+        var $placeholder = $('#petitions');
+        $.each(data.results, function(index, petition){
+          output = '<h2><a href="'+petition.url+'">'+petition.title+'</a></h2>';
+          output += '<ul>';
+          output += '<li><strong>Image:</strong> '+petition.image_url+'</li>';
+          output += '<li><strong>Who:</strong> '+petition.who+'</li>';
+          output += '<li><strong>What:</strong> '+petition.what+'</li>';
+          output += '<li><strong>Why:</strong> '+petition.why+'</li>';
+          output += '<li><strong>Signatures:</strong> '+petition.signature_count+'</li>';
+          output += '<li><strong>URL:</strong> '+petition.url+'</li>';
+          output += '</ul><hr/>';
+          $placeholder.append(output);
+        });
+      });
+    });
+  </pre>
+</div>
+
+<form action="https://codepen.io/pen/define" method="POST" target="_blank" class="hidden">
+  <input type="hidden" name="data" class="js-data" value="">
+  <input type="submit" value="Launch Example on CodePen">
+</form>

--- a/source/includes/_json_partnership_petitions.md
+++ b/source/includes/_json_partnership_petitions.md
@@ -118,7 +118,7 @@ View and edit a working example on codepen.io:
   <pre class="codepen-js">
     $(document).ready(function(){
       $.ajax({
-        url: 'https://demo.controlshiftlabs.com/partnership/rtm-roundtable-of-mice/petitions.json',
+        url: 'https://demo.controlshiftlabs.com/partnerships/rtm-roundtable-of-mice/petitions.json',
         dataType: 'jsonp',
       })
       .done(function(data) {

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -15,6 +15,7 @@ includes:
   - json_featured_petitions
   - json_categories_list
   - json_category_petitions
+  - json_partnership_petitions
   - json_effort_petitions
   - json_effort_petitions_near
   - json_me


### PR DESCRIPTION
This adds documentation for the new `/partnerships/foo/petitions.json` endpoint.