### PR TITLE
Documentation for new Delete Signature endpoint

### DIFF
--- a/source/includes/_authenticated_api_signatures.md
+++ b/source/includes/_authenticated_api_signatures.md
@@ -15,7 +15,7 @@ Find a member by email address. Once you have obtained a member id you can use t
 
 Updates the email opt in type associated with a single signature. This can be used to change the email opt in type
 if a more legally compliant form of consent was gathered elsewhere. The email opt in type for the signature is updated
-to the opt in type specified by external_id
+to the opt in type specified by `external_id`.
 
 No history is stored recording the original consent type, it is replaced by the new one specified in the API call.
 
@@ -25,6 +25,24 @@ No history is stored recording the original consent type, it is replaced by the 
 #### POST body 
 
 `external_id=foo`
+
+### Destroy
+
+> DELETE response body for Destroy
+
+```json
+{
+  "signature": {
+    "deleted": true,
+    "id": 123,
+    "email": "foo@bar.com"
+  }
+}
+```
+
+Permanently deletes the signature with the specified ID. Note that this will decrement the signature count on the petition.
+
+`DELETE /api/v1/petitions/no-taxes-on-tea/signatures/123`
 
 ### List
 


### PR DESCRIPTION
This adds documentation for the new API endpoint for deleting a signature.

![destroy](https://user-images.githubusercontent.com/1977279/41474696-ad32c1f6-708a-11e8-8c88-2876e953aa6e.png)

Note this should not be merged until https://github.com/controlshift/agra/pull/1694 is merged and deployed.