### PR TITLE
Add docs for /api/local/points

### DIFF
--- a/source/includes/_json_local_points.md
+++ b/source/includes/_json_local_points.md
@@ -1,0 +1,44 @@
+## Get organizing locations
+
+```js
+$(document).ready(function(){
+  $.ajax({
+    url: 'https://demo.controlshiftlabs.com/api/local/points.json',
+    dataType: 'jsonp',
+  })
+  .done(function(data) {
+    console.log(data);
+  });
+});
+```
+
+> The above code would retrieve point locations and log them to the js console. The JSON would be structured like this:
+
+```json
+[
+    {
+        "lat": 40.7032775,
+        "lon": -74.0170279,
+        "type": "Event",
+        "id": "picnic-in-the-park"
+    },
+    {
+        "lat": 8.2710078,
+        "lon": 148.0209055,
+        "type": "Group",
+        "id": "default-org-mariana-trench"
+    },
+    {
+        "lat": 41.467116,
+        "lon": -73.9992597,
+        "type": "ExternalEvent",
+        "id": "https://example.com/sail-on-the-hudson"
+    }
+]
+```
+
+This JSON endpoint returns a list of latitude/longitude coordinates for events, groups, and external events in your organisation. It's intended to be used for plotting organizing activities on a map.
+
+### HTTP Request
+
+`GET https://demo.controlshiftlabs.com/api/local/points.json`

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -19,6 +19,7 @@ includes:
   - json_effort_petitions
   - json_effort_petitions_near
   - json_calendars
+  - json_local_points
   - json_me
   - webhooks.md.erb
   - bulk_data


### PR DESCRIPTION
This adds documentation for the new `/api/local/points` endpoint.

![docs](https://user-images.githubusercontent.com/1977279/57399371-12c2b600-719f-11e9-9356-19bf504fcf1a.png)
