### PR TITLE
Authenticated API updates

### DIFF
--- a/source/includes/_authenticated_api_events.md
+++ b/source/includes/_authenticated_api_events.md
@@ -39,7 +39,8 @@ Events represent real-world or virtual meetings that members can RSVP to. RSVP r
     "petition": {
       "slug": "repair-the-yellow-brick-road-1",
       "url": "https://demo.controlshiftlabs.com/petitions/repair-the-yellow-brick-road-1"
-    }
+    },
+    "labels": ["oz-organizer-help"]
 }
 ```
 

--- a/source/includes/_authenticated_api_events.md
+++ b/source/includes/_authenticated_api_events.md
@@ -2,6 +2,62 @@
 
 Events represent real-world or virtual meetings that members can RSVP to. RSVP records are called "attendees".
 
+### List
+
+> GET response body
+
+```json
+{
+  "events": [
+    {
+      "slug": "deliver-the-petition-to-the-wizard",
+      "title": "Deliver the Petition to the Wizard",
+      "url": "https://demo.controlshiftlabs.com/events/deliver-the-petition-to-the-wizard",
+      "description": "Join us as we travel to the Emerald City to deliver our petition to the Wizard.",
+      "start_at": "2018-03-01T12:00:00Z",
+      "end_at": "2018-03-01T13:30:00Z",
+      "start_in_zone": "2018-03-01T12:00:00-05:00",
+      "end_in_zone": "2018-03-01T13:30:00-05:00",
+      "time_zone": "America/New_York",
+      "virtual": false,
+      "launched_at": "2018-02-03T12:34:56Z",
+      "locale": "en-US",
+      "host_address": null,
+      "max_attendees_count": null,
+      "external_id": "control-shift-deliver-the-petition-to-the-wizard",
+      "location": {
+        "query": "wizard room",
+        "latitude": "42.3376368",
+        "longitude": "-70.99304",
+        "venue": "The Wizard's Throne Room",
+        "street_number": "",
+        "street": "",
+        "region": "MA",
+        "postal_code": "",
+        "country": "US",
+        "created_at": "2017-11-16T22:38:29Z"
+      },
+      "petition": {
+        "slug": "repair-the-yellow-brick-road-1",
+        "url": "https://demo.controlshiftlabs.com/petitions/repair-the-yellow-brick-road-1"
+      },
+      "labels": ["oz-organizer-help"]
+    },
+    ...
+  ],
+  "meta": {
+    "current_page": 1,
+    "total_pages": 1,
+    "previous_page": null,
+    "next_page": null
+  }
+}
+```
+
+Get a paginated list of all events, including ones that are unlaunched or otherwise not visible to the public. Includes all the same data as the single-event endpoint for each event.
+
+`GET /api/v1/events?page=1`
+
 ### Show
 
 > GET response Body
@@ -41,6 +97,7 @@ Events represent real-world or virtual meetings that members can RSVP to. RSVP r
       "url": "https://demo.controlshiftlabs.com/petitions/repair-the-yellow-brick-road-1"
     },
     "labels": ["oz-organizer-help"]
+  }
 }
 ```
 

--- a/source/includes/_authenticated_api_partnerships.md
+++ b/source/includes/_authenticated_api_partnerships.md
@@ -2,6 +2,57 @@
 
 Partnerships are other organisations you collaborate with 
 
+### List
+
+> GET response body
+
+```json
+{
+  "partnerships": [
+    {
+      "slug": "fight-fascism",
+      "title": "Fight Fascism",
+      "description": "Fighting fascism one day at a time. With petitions.",
+      "external_id": "no-fascism-123",
+      "created_at": "2015-12-02T01:43:17Z",
+      "updated_at": "2015-12-02T01:43:17Z",
+      "url": "https://demo.controlshiftlabs.com/partnerships/fight-fascism",
+      "image": {
+        "urls": {
+          "open_graph": "http://cdn.example.com/partnerships/images/25/open_graph/a-little-teapot.png?1516647704",
+          "horizontal": "http://cdn.example.com/partnerships/images/25/horizontal/a-little-teapot.png?1516647704",
+          "hero": "http://cdn.example.com/partnerships/images/25/hero/a-little-teapot.png?1516647704",
+          "original": "http://cdn.example.com/partnerships/images/25/original/a-little-teapot.png?1516647704",
+          "form": "http://cdn.example.com/partnerships/images/25/form/a-little-teapot.png?1516647704"
+        }
+      }
+    },
+    {
+      "slug": "save-whales",
+      "title": "Save the Whales",
+      "description": "We're devoted to all policies that are good for whales.",
+      "external_id": null,
+      "created_at": "2018-01-02T12:32:45Z",
+      "updated_at": "2018-12-22T01:43:17Z",
+      "url": "https://demo.controlshiftlabs.com/partnerships/save-whales",
+      "image": null
+    }
+  ],
+  "meta": {
+    "current_page": 1,
+    "total_pages": 1,
+    "previous_page": null,
+    "next_page": null
+  }
+}
+```
+
+Get a paginated list of all partnerships.
+
+`GET /api/v1/partnerships?page=1`
+
+
+
 ### Show
 
 > GET response Body
@@ -10,8 +61,11 @@ Partnerships are other organisations you collaborate with
 {
   "partnership": {
     "slug": "fight-fascism",
-    "name": "Fight Fascism",
+    "title": "Fight Fascism",
     "description": "Fighting fascism one day at a time. With petitions.",
+    "external_id": "no-fascism-123",
+    "created_at": "2015-12-02T01:43:17Z",
+    "updated_at": "2015-12-02T01:43:17Z",
     "url": "https://demo.controlshiftlabs.com/partnerships/fight-fascism",
     "image": {
       "urls": {

--- a/source/includes/_authenticated_api_petitions.md
+++ b/source/includes/_authenticated_api_petitions.md
@@ -21,7 +21,23 @@ Petition are pieces of content that can be signed by members.
     "updated_at": "2018-03-05T15:02:02Z",
     "signature_count_add_amount": 100
     "source": "effort_near",
-    "admin_notes": "We should have a call with this campaigner but they have no telephone.",
+    "admin_notes": [
+      {
+        "source": "legacy",
+        "body": "An older note about this campaign",
+        "created_at": "2018-01-25T23:45:12Z",
+        "user": null
+      },
+      {
+        "source": "user",
+        "body": "We should have a call with this campaigner but they have no telephone.",
+        "created_at": "2019-10-09T12:34:45Z",
+        "user": {
+          "email": "organiser_2@example.com",
+          "full_name": "Sarah Organiser"
+        }
+      }
+    ],
     "url": "https://demo.controlshiftlabs.com/petitions/no-taxes-on-tea",
     "public_who": "King George",
     "public_signature_count": 234,

--- a/source/includes/_authenticated_api_petitions.md
+++ b/source/includes/_authenticated_api_petitions.md
@@ -113,6 +113,43 @@ Find information about a petition by URL slug.
 
 
 
+### List
+
+> GET response body
+
+```json
+{
+  "petitions": [
+    {
+      "id": 123,
+      "slug": "no-taxes-on-tea",
+      "title": "No Taxes on Tea",
+      ...
+    },
+    {
+      "id": 124,
+      "slug": "stop-burning-coal-1",
+      "title": "Stop Burning Coal",
+      ...
+    },
+    ...
+  ],
+
+  "meta": {
+    "current_page": 1,
+    "total_pages": 12,
+    "previous_page": null,
+    "next_page": 2
+  }
+}
+```
+
+Get a paginated list of all petitions, including ones that are unlaunched or otherwise not visible to the public. Includes all the same data as the single-petition endpoint for each petition.
+
+`GET /api/v1/petitions?page=1`
+
+
+
 ### Update
 
 Updates petition content using an HTTP PUT request.

--- a/source/includes/_authenticated_api_petitions.md
+++ b/source/includes/_authenticated_api_petitions.md
@@ -9,6 +9,7 @@ Petition are pieces of content that can be signed by members.
 ```json
 {
   "petition": {
+    "id": 123,
     "slug": "no-taxes-on-tea",
     "title": "No Taxes on Tea",
     "who": "King George",


### PR DESCRIPTION
This makes several updates to the authenticated API documentation:
- `/api/v1/petitions/foo` response includes `id`
- Change of `admin_notes` format in `/api/v1/petitions/foo` response
- Update fields in `/api/v1/partnerships/foo` response
- Add `labels` to `/api/v1/events/foo` response
- Add `/api/v1/petitions` endpoint
- Add `/api/v1/partnerships` endpoint
- Add `/api/v1/events` endpoint