### PR TITLE
Fix ToC links for duplicated headers

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,7 @@
 # Unique header generation
-require './lib/unique_head.rb'
+# Fix for issue with header titles that are duplicated in different sections of the ToC
+# from: https://github.com/slatedocs/slate/issues/738#issuecomment-406353752
+require './lib/nesting_unique_head.rb'
 
 # Markdown
 set :markdown_engine, :redcarpet
@@ -12,7 +14,7 @@ set :markdown,
     tables: true,
     with_toc_data: true,
     no_intra_emphasis: true,
-    renderer: UniqueHeadCounter
+    renderer: NestingUniqueHeadCounter
 
 # Assets
 set :css_dir, 'stylesheets'


### PR DESCRIPTION
This changes e.g., the HTML id for `Petitions` within `Authenticated REST API` section of table of contents to be #authenticated-rest-api-petitions, so that we don't have collisions between the ids resulting in wrong links in the table of contents. 

This change means that if customers have existing links saved for their convenience, those links don't work anymore. But they'll be able to use the site, just won't jump to the right section of the page immediately (have to re-use the table of contents), so it should not be too confusing. 