### PR TITLE
DRY labelings documentation

### DIFF
--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -167,36 +167,5 @@ web_conference_url | String | Video call or web conference tool URL for attendee
 
 <div></div>
 
-### Apply Label
-
-Applies an existing Label to a specific Event.
-
-**Note:** Currently it is not possible to create Labels via the API. The Label needs to exists to allow tagging an Event with it.
-
-The request body must include a `name` attribute with the name of the label to be applied to the Event.
-
-Event show URLs are constructed using the slug field as a unique identifier for each event.
-
-`POST /api/v1/events/deliver-the-petition-to-the-wizard/labelings`
-
-Response on success will not have a body, and status code will be `201 - Created`
-
-> POST request body
-
-```json
-{
-  "name": "Oz"
-}
-```
-
-<div></div>
-
-### Remove Label
-
-Removes a Label from the Event.
-
-The name of the Label must be included in the URL and be correctly percent encoded as per RFC 3986.
-
-Response on success will not have a body, and status code will be `200 - Ok`
-
-`DELETE /api/v1/events/deliver-the-petition-to-the-wizard/labelings/Oz`
+<%= partial "includes/authenticated_api/labelings.md.erb",
+            locals: {campaign_type: 'event', path_prefix: '/api/v1/events/deliver-the-petition-to-the-wizard'} %>

--- a/source/includes/authenticated_api/_labelings.md.erb
+++ b/source/includes/authenticated_api/_labelings.md.erb
@@ -1,0 +1,35 @@
+### Apply Label
+
+> POST request body
+
+```json
+{
+  "name": "We Love Tea!"
+}
+```
+
+Applies an existing Label to a specific <%= campaign_type %>.
+
+**Note:** Currently it is not possible to create Labels via the API. The Label needs to exists to allow tagging the <%= campaign_type %> with it.
+
+The request body must include a `name` attribute with the name of the label to be applied to the <%= campaign_type %>.
+
+`POST <%= path_prefix %>/labelings`
+
+Response on success will not have a body, and status code will be `201 - Created`
+
+This example would apply the "We Love Tea!" label to the <%= campaign_type %>.
+
+<div></div>
+
+### Remove Label
+
+Removes a Label from the <%= campaign_type %>.
+
+The name of the Label must be included in the URL and be correctly percent encoded as per RFC 3986.
+
+Response on success will not have a body, and status code will be `200 - Ok`
+
+`DELETE <%= path_prefix %>/labelings/We%20Love%20Tea%21`
+
+This example would remove the "We Love Tea!" label from the <%= campaign_type %>.

--- a/source/includes/authenticated_api/_local_chapters.md.erb
+++ b/source/includes/authenticated_api/_local_chapters.md.erb
@@ -42,37 +42,5 @@ meta           | pagination information
 local_chapter  | Basic information about the local group
 members        | Array of information about each supporter in this group
 
-### Apply Label
-<div></div>
-
-Applies an existing Label to a specific Local Group.
-
-**Note:** Currently it is not possible to create Labels via the API. The Label needs to exists to allow tagging an Local Group with it.
-
-The request body must include a `name` attribute with the name of the label to be applied to the Local Group.
-
-`POST /api/v1/local_chapters/save-gotham/labelings`
-
-Response on success will not have a body, and status code will be `201 - Created`
-
-> POST request body
-
-```json
-{
-  "name": "official"
-}
-```
-
-In this example we add the label "official" to the Local Group with slug `save-gotham`
-
-### Remove Label
-
-Removes a Label from the Local Group.
-
-The name of the Label must be included in the URL and be correctly percent encoded as per RFC 3986.
-
-Response on success will not have a body, and status code will be `200 - Ok`
-
-`DELETE /api/v1/local_chapters/save-gotham/labelings/official`
-
-In this example we remove the label "official" from the Local Group with slug `save-gotham`
+<%= partial "includes/authenticated_api/labelings.md.erb",
+            locals: {campaign_type: 'local group', path_prefix: '/api/v1/local-chapters/tea-drinking-society'} %>

--- a/source/includes/authenticated_api/_petitions.md.erb
+++ b/source/includes/authenticated_api/_petitions.md.erb
@@ -238,39 +238,5 @@ destroyed.
 
 <div></div>
 
-
-### Apply Label
-
-> POST request body
-
-```json
-{
-  "name": "We Love Tea!"
-}
-```
-
-Applies an existing Label to a specific Petition.
-
-**Note:** Currently it is not possible to create Labels via the API. The Label needs to exists to allow tagging a Petition with it.
-
-The request body must include a `name` attribute with the name of the label to be applied to the Petition.
-
-`POST /api/v1/petitions/no-taxes-on-tea/labelings`
-
-Response on success will not have a body, and status code will be `201 - Created`
-
-This example would apply the "We Love Tea!" label to the petition.
-
-<div></div>
-
-### Remove Label
-
-Removes a Label from the Petition.
-
-The name of the Label must be included in the URL and be correctly percent encoded as per RFC 3986.
-
-Response on success will not have a body, and status code will be `200 - Ok`
-
-`DELETE /api/v1/petitions/no-taxes-on-tea/labelings/We%20Love%20Tea%21`
-
-This example would remove the "We Love Tea!" label from the petition.
+<%= partial "includes/authenticated_api/labelings.md.erb",
+            locals: {campaign_type: 'petition', path_prefix: '/api/v1/petitions/no-taxes-on-tea'} %>


### PR DESCRIPTION
This DRYs the documentation about adding/removing labelings from Petitions, Events, and Groups.