### PR TITLE
Document mentor endpoints

### DIFF
--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -169,3 +169,6 @@ web_conference_url | String | Video call or web conference tool URL for attendee
 
 <%= partial "includes/authenticated_api/labelings.md.erb",
             locals: {campaign_type: 'event', path_prefix: '/api/v1/events/deliver-the-petition-to-the-wizard'} %>
+
+<%= partial "includes/authenticated_api/mentor.md.erb",
+            locals: {campaign_type: 'event', path_prefix: '/api/v1/events/deliver-the-petition-to-the-wizard'} %>

--- a/source/includes/authenticated_api/_local_chapters.md.erb
+++ b/source/includes/authenticated_api/_local_chapters.md.erb
@@ -44,3 +44,6 @@ members        | Array of information about each supporter in this group
 
 <%= partial "includes/authenticated_api/labelings.md.erb",
             locals: {campaign_type: 'local group', path_prefix: '/api/v1/local-chapters/tea-drinking-society'} %>
+
+<%= partial "includes/authenticated_api/mentor.md.erb",
+            locals: {campaign_type: 'local group', path_prefix: '/api/v1/local-chapters/tea-drinking-society'} %>

--- a/source/includes/authenticated_api/_mentor.md.erb
+++ b/source/includes/authenticated_api/_mentor.md.erb
@@ -16,9 +16,13 @@
 {
   "status": "success",
   "data": {
-    "id": 123,
-    "name": "Suzie Greenberg",
-    "initials": "SG"
+    "mentor": {
+      "email": "suzie@example.com",
+      "member_id": 123,
+      "full_name": "Suzie Greenberg",
+      "phone_number": "555-555-5555",
+      "postcode": "12345"
+    }
   }
 }
 ```

--- a/source/includes/authenticated_api/_mentor.md.erb
+++ b/source/includes/authenticated_api/_mentor.md.erb
@@ -1,4 +1,4 @@
-### Assign mentor
+### Assign Mentor
 
 > PUT request body
 

--- a/source/includes/authenticated_api/_mentor.md.erb
+++ b/source/includes/authenticated_api/_mentor.md.erb
@@ -1,0 +1,40 @@
+### Assign mentor
+
+> PUT request body
+
+```json
+{
+  "mentor": {
+    "email": "suzie@example.com"
+  }
+}
+```
+
+> PUT request response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "id": 123,
+    "name": "Suzie Greenberg",
+    "initials": "SG"
+  }
+}
+```
+
+Assigns an admin user as the mentor for the <%= campaign_type %>.
+
+The email address specified will be used to look up an admin user who will be assigned as the <%= campaign_type %>'s mentor.
+
+`PUT <%= path_prefix %>/mentor`
+
+> PUT request body
+
+```json
+{
+  "mentor": null
+}
+```
+
+To remove the mentor from the <%= campaign_type %>, the request body should include `null` instead of the email block.

--- a/source/includes/authenticated_api/_petitions.md.erb
+++ b/source/includes/authenticated_api/_petitions.md.erb
@@ -240,3 +240,6 @@ destroyed.
 
 <%= partial "includes/authenticated_api/labelings.md.erb",
             locals: {campaign_type: 'petition', path_prefix: '/api/v1/petitions/no-taxes-on-tea'} %>
+
+<%= partial "includes/authenticated_api/mentor.md.erb",
+            locals: {campaign_type: 'petition', path_prefix: '/api/v1/petitions/no-taxes-on-tea'} %>


### PR DESCRIPTION
This adds documentation for the new endpoints that allow setting the **mentor** for a petition, event, or group.
![mentor2](https://user-images.githubusercontent.com/1977279/129059012-ca00a774-5d2c-498e-b60d-3ad04300b32b.png)