### PR TITLE
Update docs for petition and event endpoints to include mentor data

### DIFF
--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -113,6 +113,13 @@ Event show URLs are constructed using the slug field as a unique identifier.
       "country": "US",
       "created_at": "2017-11-16T22:38:29Z"
     },
+    "mentor": {
+      "member_id": 456,
+      "full_name": "Glinda the Good",
+      "email": "glinda@example.com",
+      "phone_number": "555-555-5555",
+      "postcode": "12345"
+    },
     "petition": {
       "slug": "repair-the-yellow-brick-road-1",
       "url": "https://demo.controlshiftlabs.com/petitions/repair-the-yellow-brick-road-1"

--- a/source/includes/authenticated_api/_petitions.md.erb
+++ b/source/includes/authenticated_api/_petitions.md.erb
@@ -65,6 +65,13 @@ Petition are pieces of content that can be signed by members.
       "email": "patrick.henry@example.com",
       "phone_number": "555-555-5555"
     },
+    "mentor": {
+      "member_id": 123,
+      "full_name": "Alexander Hamilton",
+      "email": "alex.hamilton@example.com",
+      "phone_number": null,
+      "postcode": "12345"
+    },
     "location": {
       "query": "boston harbor",
       "latitude": "42.3376368",


### PR DESCRIPTION
This documents the changes from https://github.com/controlshift/agra/pull/5624 by including the `"mentor"` block in the Petitions/show and Events/show example responses.

Not included: Adding an example response for Local Chapters/show