### PR TITLE
Document reviewer endpoints

### DIFF
--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -179,3 +179,8 @@ web_conference_url | String | Video call or web conference tool URL for attendee
 
 <%= partial "includes/authenticated_api/mentor.md.erb",
             locals: {campaign_type: 'event', path_prefix: '/api/v1/events/deliver-the-petition-to-the-wizard'} %>
+
+<div></div>
+
+<%= partial "includes/authenticated_api/reviewer.md.erb",
+            locals: {campaign_type: 'event', path_prefix: '/api/v1/events/deliver-the-petition-to-the-wizard'} %>

--- a/source/includes/authenticated_api/_petitions.md.erb
+++ b/source/includes/authenticated_api/_petitions.md.erb
@@ -253,3 +253,8 @@ destroyed.
 
 <%= partial "includes/authenticated_api/mentor.md.erb",
             locals: {campaign_type: 'petition', path_prefix: '/api/v1/petitions/no-taxes-on-tea'} %>
+
+<div></div>
+
+<%= partial "includes/authenticated_api/reviewer.md.erb",
+            locals: {campaign_type: 'petition', path_prefix: '/api/v1/petitions/no-taxes-on-tea'} %>

--- a/source/includes/authenticated_api/_reviewer.md.erb
+++ b/source/includes/authenticated_api/_reviewer.md.erb
@@ -1,5 +1,9 @@
 ### Assign Reviewer
 
+To allow delegation of moderation tasks to specific people or teams, the platform allows specifying a reviewer for each <%= campaign_type %>.
+
+Staff are able to filter the moderation queue to just the tasks that have been assigned to them through the ControlShift platform web interface. 
+
 > PUT request body
 
 ```json
@@ -57,7 +61,7 @@
 
 Assigns an admin user or team as the reviewer for the <%= campaign_type %> that is pending moderation.
 
-The email address or slug will be used to look up an admin user or team that will be assigned to review the <%= campaign_type %>.
+The email address or team slug will be used to look up an admin user or team that will be assigned to review the <%= campaign_type %>.
 
 `PUT <%= path_prefix %>/reviewer`
 

--- a/source/includes/authenticated_api/_reviewer.md.erb
+++ b/source/includes/authenticated_api/_reviewer.md.erb
@@ -1,0 +1,72 @@
+### Assign Reviewer
+
+> PUT request body
+
+```json
+{
+  "reviewer": {
+    "type": "User",
+    "email": "suzie@example.com"
+  }
+}
+```
+
+> PUT request response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "reviewer": {
+      "type": "User",
+      "email": "suzie@example.com",
+      "full_name": "Suzie Greenberg",
+      "member_id": 123,
+      "phone_number": "555-555-5555",
+      "postcode": "12345"
+    }
+  }
+}
+```
+
+> PUT request body
+
+```json
+{
+  "reviewer": {
+    "type": "Team",
+    "slug": "moderation-helpers"
+  }
+}
+```
+
+> PUT request response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "reviewer": {
+      "type": "Team",
+      "name": "Moderation Helpers",
+      "slug": "moderation-helpers"
+    }
+  }
+}
+```
+
+Assigns an admin user or team as the reviewer for the <%= campaign_type %> that is pending moderation.
+
+The email address or slug will be used to look up an admin user or team that will be assigned to review the <%= campaign_type %>.
+
+`PUT <%= path_prefix %>/reviewer`
+
+> PUT request body
+
+```json
+{
+  "reviewer": null
+}
+```
+
+To remove the reviewer from the <%= campaign_type %>, the request body should include `null` instead of the email or slug block.


### PR DESCRIPTION
This adds documentation for the new endpoints that allow setting the **reviewer** for a petition or event.
![petition](https://user-images.githubusercontent.com/1977279/129740220-9eb56bcd-57f2-464d-a711-a31b1dc56fda.png)

This documents the changes from https://github.com/controlshift/agra/pull/5644