### PR TITLE
Group JSON API Endpoints information into sections

### DIFF
--- a/source/includes/json/_bulk_data.md.erb
+++ b/source/includes/json/_bulk_data.md.erb
@@ -1,0 +1,4 @@
+## Bulk Data
+
+<%= partial "includes/json/bulk_data_schema.md" %>
+<%= partial "includes/json/bulk_data_columns.md" %>

--- a/source/includes/json/_bulk_data_columns.md
+++ b/source/includes/json/_bulk_data_columns.md
@@ -1,4 +1,4 @@
-## Bulk data columns
+### Bulk data columns
 
 This retrieves information on the tables exported by the Bulk Data API. For convenience when working with third-party data 
 warehouse tools like Amazon Redshift it can be useful to know the current columns for each table that the bulk data API exposes
@@ -13,12 +13,14 @@ which table header row is returned.
 id,petition_id,email,first_name,last_name,phone_number,postcode,created_at,join_organisation,deleted_at,unsubscribe_at,external_constituent_id,member_id,additional_fields,cached_organisation_slug,source,external_id,new_member,external_action_id,locale,bucket,country,updated_at,user_ip,confirmation_token,confirmed_at,confirmation_sent_at,last_signed_at,join_list_suppressed,old_daisy_chain_used,from_embed,user_agent,confirmed_reason,synced_to_crm_at,daisy_chain_experiment_slug,eu_data_processing_consent,from_one_click,consent_content_version_id,daisy_chain_id_used,email_opt_in_type_id,facebook_id,utm_params,postcode_id,referring_share_click_id,join_partnership,opt_in_sms,sms_opt_in_type_id,recaptcha_score,new_mobile_subscriber
 ```
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/api/bulk_data/schema/columns?table=signatures`
 
-### Query Parameters
+#### Query Parameters
 
 Parameter |  Description
 --------- | ------------------
 table     |  Which table from the bulk data schema endpoint should be returned
+
+<div></div>

--- a/source/includes/json/_bulk_data_schema.md
+++ b/source/includes/json/_bulk_data_schema.md
@@ -1,4 +1,4 @@
-## Bulk data schema
+### Bulk data schema
 
 This retrieves information on the underlying schemas of tables exported by the Bulk Data feature. It can be used
 in your ETL processes to automate the setup of tables in your data warehouse.
@@ -40,6 +40,8 @@ If the _Compress bulk data exports_ option is enabled, the extra `compression_fo
 }
 ```
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/api/bulk_data/schema.json`
+
+<div></div>

--- a/source/includes/json/_calendar.md
+++ b/source/includes/json/_calendar.md
@@ -1,4 +1,4 @@
-## Get calendar data
+### Get calendar data
 
 ```js
 $(document).ready(function(){
@@ -31,8 +31,9 @@ $(document).ready(function(){
 
 This retrieves a JSON object representing a calendar.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/calendars/slug.json`
 
 Where slug is the slug of the calendar you're retrieving. 
+<div></div>

--- a/source/includes/json/_calendars.md.erb
+++ b/source/includes/json/_calendars.md.erb
@@ -1,0 +1,3 @@
+## Calendars
+
+<%= partial "includes/json/calendar.md" %>

--- a/source/includes/json/_categories.md.erb
+++ b/source/includes/json/_categories.md.erb
@@ -1,0 +1,4 @@
+## Categories
+
+<%= partial "includes/json/categories_list.md" %>
+<%= partial "includes/json/category_petitions.md" %>

--- a/source/includes/json/_categories_list.md
+++ b/source/includes/json/_categories_list.md
@@ -1,4 +1,4 @@
-## Get list of categories
+### Get list of categories
 
 ```js
 $(document).ready(function(){
@@ -41,11 +41,11 @@ $(document).ready(function(){
 
 This retrieves a JSON array of category objects.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/categories.json`
 
-### Working Example
+#### Working Example
 
 View and edit a working example on codepen.io:
 
@@ -81,3 +81,5 @@ View and edit a working example on codepen.io:
   <input type="hidden" name="data" class="js-data" value="">
   <input type="submit" value="Launch Example on CodePen">
 </form>
+
+<div></div>

--- a/source/includes/json/_category_petitions.md
+++ b/source/includes/json/_category_petitions.md
@@ -1,4 +1,4 @@
-## List petitions in a category
+### List petitions in a category
 
 ```js
 $(document).ready(function(){
@@ -145,18 +145,18 @@ $(document).ready(function(){
 
 This retrieves a paginated list of petitions in a category.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/categories/<category slug>.json`
 
-### Query Parameters
+#### Query Parameters
 
 Parameter | Default | Description
 --------- | ------- | -----------
 category slug | null | string - required - submitted as a part of the endpoint path, not as a separate URL parameter
 page | 1 | integer - optional - The page number of results for the specified category. Minimum of 1.
 
-### Working Example
+#### Working Example
 
 View and edit a working example on codepen.io:
 
@@ -199,3 +199,4 @@ View and edit a working example on codepen.io:
   <input type="hidden" name="data" class="js-data" value="">
   <input type="submit" value="Launch Example on CodePen">
 </form>
+<div></div>

--- a/source/includes/json/_effort_petitions.md
+++ b/source/includes/json/_effort_petitions.md
@@ -1,4 +1,4 @@
-## List petitions in an effort
+### List petitions in an effort
 
 ```js
 $(document).ready(function(){
@@ -133,7 +133,7 @@ Additionally, successful petitions will have the `successful` attribute set to `
 
 * `ended_story`: with ended story from petition Settings / Admin pages.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/efforts/<effort slug>.json`
 
@@ -141,7 +141,7 @@ Parameter | Default | Description
 --------- | ------- | -----------
 effort slug | null | string - required - submitted as a part of the endpoint path, not as a separate URL parameter
 
-### Working Example
+#### Working Example
 
 View and edit a working example on codepen.io:
 
@@ -193,3 +193,4 @@ View and edit a working example on codepen.io:
   <input type="hidden" name="data" class="js-data" value="">
   <input type="submit" value="Launch Example on CodePen">
 </form>
+<div></div>

--- a/source/includes/json/_effort_petitions_near.md
+++ b/source/includes/json/_effort_petitions_near.md
@@ -1,10 +1,10 @@
-## Search petitions in a effort
+### Search petitions in a effort
 
 ```js
 $(document).ready(function(){
   var effortSlug = 'drivers-licenses-for-all';
   $.ajax({
-    url: 'https://demo.controlshiftlabs.com/efforts/'+effortSlug+'/'+'lookup/query.json',
+    url: 'https://demo.controlshiftlabs.com/efforts/'+effortSlug+'/lookup/query.json',
     dataType: 'jsonp',
     data: {
       'location_query': 'briarcliff manor, ny'
@@ -15,7 +15,6 @@ $(document).ready(function(){
   });
 });
 ```
-<!--slash in '/'+'lookup/query.json' above disappears if combined with lookup/query-->
 
 > The above code would return petitions, decision makers, or objectives data from the effort with the slug `drivers-licenses-for-all`. If returning decision makers, the JSON would be structured like this:
 
@@ -54,11 +53,11 @@ $(document).ready(function(){
 This JSON endpoint allows you to build an interface where users can search the petitions in an effort.
 Depending on how the effort is configured, you can search either by location, or by keyword.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/efforts/<effort slug>/lookup/query.json`
 
-### Query Parameters
+#### Query Parameters
 
 Parameter | Required? | Description
 --------- | ------- | -----------
@@ -66,7 +65,7 @@ effort slug | yes | string - submitted as a part of the endpoint path, not as a 
 location_query | yes, if effort is configured for location search | string to search for (will be geocoded on the server)
 query | yes, if effort is configured for keyword search | string to search for
 
-### Working Example
+#### Working Example
 
 View and edit a working example on codepen.io:
 
@@ -138,3 +137,4 @@ View and edit a working example on codepen.io:
   <input type="hidden" name="data" class="js-data" value="">
   <input type="submit" value="Launch Example on CodePen">
 </form>
+<div></div>

--- a/source/includes/json/_efforts.md.erb
+++ b/source/includes/json/_efforts.md.erb
@@ -1,0 +1,4 @@
+## Efforts
+
+<%= partial "includes/json/effort_petitions.md" %>
+<%= partial "includes/json/effort_petitions_near.md" %>

--- a/source/includes/json/_featured_petitions.md
+++ b/source/includes/json/_featured_petitions.md
@@ -1,4 +1,4 @@
-## Get featured petitions
+### Get featured petitions
 
 ```js
 $(document).ready(function(){
@@ -150,17 +150,17 @@ This retrieves a JSON object compliant with the [JSON API](http://jsonapi.org/) 
 
 **Important Note:** The previous featured petitions API endpoint at `https://demo.controlshiftlabs.com/featured.json` (note the missing `/petitions` path) is being deprecated and **will be removed** in the near future. Please use this new endpoint for retrieving featured petitions from now on.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/petitions/featured.json`
 
-### Query Parameters
+#### Query Parameters
 
 Parameter | Default | Description
 --------- | ------- | -----------
 locale | null | string - optional - Locale filter for petitions
 
-### Working Example
+#### Working Example
 
 View and edit a working example on codepen.io:
 
@@ -196,3 +196,5 @@ View and edit a working example on codepen.io:
   <input type="hidden" name="data" class="js-data" value="">
   <input type="submit" value="Launch Example on CodePen">
 </form>
+
+<div></div>

--- a/source/includes/json/_local.md.erb
+++ b/source/includes/json/_local.md.erb
@@ -1,0 +1,4 @@
+## Local Map
+
+<%= partial "includes/json/local_points.md" %>
+<%= partial "includes/json/local_details.md" %>

--- a/source/includes/json/_local_details.md
+++ b/source/includes/json/_local_details.md
@@ -1,4 +1,4 @@
-## Get organizing locations: details
+### Get organizing locations: details
 
 ```js
 $(document).ready(function(){
@@ -50,13 +50,15 @@ $(document).ready(function(){
 This JSON endpoint returns a paginated list of publicly listed events, groups, and external events in your organisation.
 It can be used alongside the `/api/local/points` endpoint; the criteria for inclusion are the same.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/api/local.json`
 
-### Query Parameters
+#### Query Parameters
 
 Parameter | Default | Description
 --------- | ------- | -----------
 page      | 1       | (optional) Which page of results to fetch
 per_page  | 10      | (optional) How many results, maximum, should be included on each page
+
+<div></div>

--- a/source/includes/json/_local_points.md
+++ b/source/includes/json/_local_points.md
@@ -1,4 +1,4 @@
-## Get organizing locations: points
+### Get organizing locations: points
 
 ```js
 $(document).ready(function(){
@@ -39,6 +39,7 @@ $(document).ready(function(){
 
 This JSON endpoint returns a complete list of latitude/longitude coordinates for publicly listed events, groups, and external events in your organisation. It's intended to be used for plotting organizing activities on a map.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/api/local/points.json`
+<div></div>

--- a/source/includes/json/_partnership_petitions.md
+++ b/source/includes/json/_partnership_petitions.md
@@ -1,4 +1,4 @@
-## List petitions in a partnership
+### List petitions in a partnership
 
 ```js
 $(document).ready(function(){
@@ -146,18 +146,18 @@ $(document).ready(function(){
 
 This retrieves a paginated list of petitions in a partnership.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/partnerships/<partnership slug>/petitions.json`
 
-### Query Parameters
+#### Query Parameters
 
 Parameter | Default | Description
 --------- | ------- | -----------
 partnership slug | null | string - required - submitted as a part of the endpoint path, not as a separate URL parameter
 page | 1 | integer - optional - The page number of results for the specified partnership. Minimum of 1.
 
-### Working Example
+#### Working Example
 
 View and edit a working example on codepen.io:
 
@@ -200,3 +200,4 @@ View and edit a working example on codepen.io:
   <input type="hidden" name="data" class="js-data" value="">
   <input type="submit" value="Launch Example on CodePen">
 </form>
+<div></div>

--- a/source/includes/json/_partnerships.md.erb
+++ b/source/includes/json/_partnerships.md.erb
@@ -1,0 +1,3 @@
+## Partnerships
+
+<%= partial "includes/json/partnership_petitions.md" %>

--- a/source/includes/json/_petitions.md.erb
+++ b/source/includes/json/_petitions.md.erb
@@ -1,0 +1,5 @@
+## Petitions
+
+<%= partial "includes/json/single_petition.md" %>
+<%= partial "includes/json/featured_petitions.md" %>
+<%= partial "includes/json/petitions_search.md" %>

--- a/source/includes/json/_petitions_search.md
+++ b/source/includes/json/_petitions_search.md
@@ -1,4 +1,4 @@
-## Search petitions by keyword
+### Search petitions by keyword
 
 > JSON response example for the search using the `wizard` keyword:
 
@@ -122,13 +122,15 @@
 
 This JSON endpoint allows you to build an interface where users can search through all petitions by one or more keywords.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/petitions/search.json`
 
-### Query Parameters
+#### Query Parameters
 
 Parameter | Default | Description
 --------- | ------- | -----------
 query | null | string to search for
 page | 1 | integer - optional - The page number of results for the specified search. Minimum of 1.
+
+<div></div>

--- a/source/includes/json/_single_petition.md
+++ b/source/includes/json/_single_petition.md
@@ -1,4 +1,4 @@
-## Get a single petition
+### Get a single petition
 
 ```js
 $(document).ready(function(){
@@ -66,21 +66,20 @@ $(document).ready(function(){
 
 This retrieves a single petition object.
 
-### HTTP Request
+#### HTTP Request
 
 `GET https://demo.controlshiftlabs.com/petitions/<slug>.json`
 
-### Query Parameters
+#### Query Parameters
 
 Parameter | Default | Description
 --------- | ------- | -----------
 slug | null | string - required - The petition's unique identification slug. If none is provided, you will get a 404 error. Note: submitted as a part of the endpoint path, not as a separate URL parameter
 
-### Working Example
+#### Working Example
 
 View and edit a working example on codepen.io:
 
-<div>
 <div class="js-codepen-data hidden" data-title="ControlShift Labs: Single Petition Example">
   <div class="codepen-html">
     <div id="js-content-wrapper" class="hidden">
@@ -118,4 +117,5 @@ View and edit a working example on codepen.io:
   <input type="hidden" name="data" class="js-data" value="">
   <input type="submit" value="Launch Example on CodePen">
 </form>
+<div>
 </div>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -11,20 +11,14 @@ toc_footers:
 
 includes:
   - json/intro
-  - json/single_petition
-  - json/featured_petitions
-  - json/petitions_search
-  - json/categories_list
-  - json/category_petitions
-  - json/partnership_petitions
-  - json/effort_petitions
-  - json/effort_petitions_near
-  - json/calendars
-  - json/local_points
-  - json/local
+  - json/petitions.md.erb
+  - json/categories.md.erb
+  - json/partnerships.md.erb
+  - json/efforts.md.erb
+  - json/calendars.md.erb
+  - json/local.md.erb
   - json/me
-  - json/bulk_data_schema
-  - json/bulk_data_columns
+  - json/bulk_data.md.erb
   - webhooks.md.erb
   - bulk_data.md.erb
   - authenticated_api/intro


### PR DESCRIPTION
This groups together some of the items under JSON API Endpoints, to make it easier to find the relevant information.

Before:
![image](https://user-images.githubusercontent.com/1977279/176932194-c19a3329-b522-4eaf-aa01-b2efeef49278.png)

After:
![image](https://user-images.githubusercontent.com/1977279/176932266-271d6a05-dc50-4d67-a6a2-b83a04ef3b3b.png)