### PR TITLE
Document authenticated API endpoint for creating an effort petition

### DIFF
--- a/source/includes/authenticated_api/_efforts.md.erb
+++ b/source/includes/authenticated_api/_efforts.md.erb
@@ -5,5 +5,76 @@ In efforts, each petition must be associated with a specific decision maker or o
 
 Within the API, both Efforts and Landing Pages use the `efforts` URLs.
 
+### Create Petition
+> POST /api/v1/efforts/hardware-stores-stop-selling-bee-poison/petitions
+
+```json
+{
+  "petition": {
+    "title": "Acme Hardware, Stop Selling Bee Poison!",
+    "targets": [
+      {
+        "name": "Joe Hammer",
+        "context": "Manager at Acme Hardware"
+      }
+    ],
+    "what": "Stop selling pesticides containing neonicotinoids, which the EPA has found harmful to bees.",
+    "why": "Pollinators are important.",
+    "categories": "Environment",
+    "location": {
+      "venue": "Acme Hardware",
+      "street_number": 123,
+      "street": "Main St",
+      "locality": "Chicago",
+      "region": "IL",
+    }
+  }
+}
+```
+
+> Response body
+TK
+
+Create a new petition in the effort or landing page.
+
+`POST /api/v1/efforts/hardware-stores-stop-selling-bee-poison/petitions`
+
+If a `creator` is specified, that user will become the petition's leader, and will receive an email asking them to confirm that they are leading the petition.
+Once the leader confirms, the petition will work the same way as a petition created via the web UI.
+The URL in the response is the public petition page where supporters can sign the petition.
+To update a petition after creation, use the returned `slug` with the <a href="#authenticated-rest-api-petitions-update">Petition Update</a> endpoint.
+
+Depending on how the effort or landing page is configured, several attributes may be set automatically on the created petition:
+
+- Image
+- Whether to show the progress bar
+- Whether any of the title, who, what, or why fields are locked
+
+The request body should be a JSON block containing one `"petition"` object, which can have the following properties:
+
+Field | Type | Description | Required?
+------|------|-------------|----------
+campaigner_contactable | Boolean | Whether members of the public can contact the petition creator via the public petition page | no; default is `true`
+categories | List of Strings | Names of categories that should be applied to the new petition, in addition to any default categories configured for the effort/landing page. Must be categories that already exist. If category names are translated, the original/main language names should be used here. | no; default is the categories configured on the effort/landing page
+creator | User block ([see above](#json-type-user)) | User who will be the petition leader. If a user account does not already exist with this email, we will create one. | no; default is no leader
+delivery_details | String | How the petition will be delivered | no
+external_facebook_page | String | URL of a facebook page for the campaign | no
+external_site | String | URL of a website about the campaign | no
+group[slug] | String | Unique identifier for an existing group this petition should be associated with | no
+hide_petition_creator | Boolean | Whether to suppress the display of the petition creator’s name on the petition page | no; default is `false`
+hide_recent_signers | Boolean | Whether to suppress the "recently signed" and "recently shared" display | no; default is `false`
+labels | List of Strings | Labels that should be applied to the new petition. Any labels that do not already exist will be created | no
+locale | String | The ISO 639-1 two-letter code for the language the petition content is in. Must be one of the languages supported by ControlShift. | no; defaults to organisation's default language
+location | Location block ([see above](#json-type-location)) | Information about the location associated with the petition. If latitude and longitude are included, we’ll use them. Otherwise, we’ll geocode the fields provided. | no; default is the location of the decision maker or objective in an effort, or no location in a landing page
+objective[slug] | String | Unique identifier for an existing objective this petition should be associated with. Only available within an "objectives" effort, and must be one of the objectives configured for that effort. | only if the effort is an objectives effort
+partnership[slug] | String | Unique identifier for an existing partnership this petition should be associated with | no
+petition_creator_name_override | String | Name to display on the petition page instead of the creator's account name | no
+region[slug] | String | Unique identifier for an existing region this petition should be associated with | no
+source | String | Optional, open-ended string representing where this petition came from | no; default is "API"
+targets | List of 0-1 Target blocks ([see above](#json-type-target)) | Decision makers for this petition. If a block includes a `slug`, we’ll use it to look up an existing decision maker. Otherwise, we’ll try to create a new one. In a decision-makers-based effort, the specified decision maker will be added to the effort if it is not already associated with it. Any decision maker created this way will be set to "published". Specifying more than one decision maker is not yet supported. | no; default is no decision maker
+title | String | Title of the petition. If a title is specified, it will be used, even if there is a different default. | yes, unless a default title has been specified for the effort/landing page
+what | String | Text of the petition ask. If a value is specified, it will be used, even if there is a different default. | yes, unless a default "what" has been specified for the effort/landing page
+who | String | Who the petition is addressed to. If a value is specified, it will be used, even if there is a different default. | yes, unless a default "who" has been specified for the effort/landing page or `targets` includes a decision maker
+why | String | Text explaining why the petition is important. If a value is specified, it will be used, even if there is a different default. | yes, unless a default "why" has been specified for the effort/landing page
 
 <div></div>

--- a/source/includes/authenticated_api/_efforts.md.erb
+++ b/source/includes/authenticated_api/_efforts.md.erb
@@ -33,7 +33,90 @@ Within the API, both Efforts and Landing Pages use the `efforts` URLs.
 ```
 
 > Response body
-TK
+
+```json
+{
+  "status": "success",
+  "petition": {
+    "admin_events_status": "auto",
+    "admin_status": "good",
+    "alias": null,
+    "campaigner_contactable": true,
+    "can_download_signers": true,
+    "created_at": "2019-06-01T21:32Z",
+    "custom_goal": null,
+    "delivery_details": null,
+    "external_facebook_page": null,
+    "external_site": null,
+    "goal": 100,
+    "hide_petition_creator": false,
+    "hide_recent_signers": false,
+    "hide_signature_form": false,
+    "id": 123,
+    "launched": true,
+    "locale": "en",
+    "petition_creator_name_override": null,
+    "redirect_to": null,
+    "show_progress_bar": true,
+    "signature_count_add_amount": null,
+    "slug": "acme-hardware-stop-selling-bee-poison-23",
+    "source": "API",
+    "title": "Acme Hardware, Stop Selling Bee Poison!",
+    "updated_at": "2019-06-01T21:32Z",
+    "what": "Stop selling pesticides containing neonicotinoids, which the EPA has found harmful to bees.",
+    "who": null,
+    "why": "Pollinators are important.",
+    "title_locked": false,
+    "what_locked": true,
+    "who_locked": false,
+    "why_locked": false,
+    "delivery_details_locked": null,
+    "external_facebook_page_locked": null,
+    "external_site_locked": null,
+    "categories_locked": null,
+    "url": "https://demo.controlshiftlabs.com/petitions/acme-hardware-stop-selling-bee-poison-23",
+    "public_who": "Joe Hammer, Manager at Acme Hardware",
+    "ended": false,
+    "successful": false,
+    "image": null,
+    "public_signature_count": 0,
+    "creator": null,
+    "mentor": null,
+    "reviewer": null,
+    "location": {
+      "latitude": 12.345,
+      "longitude": -34.567,
+      "postal_code": "12345",
+      "country": "US",
+      "region": "IL",
+      "locality": "Chicago",
+      "query": "Acme Hardware, 123 Main St, Chicago, IL",
+      "street": "Main St",
+      "street_number": 123,
+      "venue": "Acme Hardware",
+      "created_at": "2019-06-01T21:32Z"
+    },
+    "decision_makers": [
+      {
+        "name": "Joe Hammer",
+        "slug": "joe-hammer",
+        "context": "Manager at Acme Hardware",
+      }
+    ],
+    "effort": {
+      "slug": "hardware-stores-stop-selling-bee-poison"
+    },
+    "partnership": null,
+    "labels": [],
+    "categories": [
+      {
+        "slug": "environment",
+        "name": "Environment"
+      }
+    ]
+  }
+}
+```
 
 Create a new petition in the effort or landing page.
 

--- a/source/includes/authenticated_api/_efforts.md.erb
+++ b/source/includes/authenticated_api/_efforts.md.erb
@@ -1,0 +1,9 @@
+## Efforts and Landing Pages
+
+Efforts and Landing Pages are both collections of related petitions.
+In efforts, each petition must be associated with a specific decision maker or objective, while landing pages allow for simply grouping petitions together without the structure of decision makers or objectives.
+
+Within the API, both Efforts and Landing Pages use the `efforts` URLs.
+
+
+<div></div>

--- a/source/includes/authenticated_api/_efforts.md.erb
+++ b/source/includes/authenticated_api/_efforts.md.erb
@@ -1,7 +1,8 @@
 ## Efforts and Landing Pages
 
 Efforts and Landing Pages are both collections of related petitions.
-In efforts, each petition must be associated with a specific decision maker or objective, while landing pages allow for simply grouping petitions together without the structure of decision makers or objectives.
+In efforts, each petition must be associated with a specific decision maker or objective,
+while landing pages allow for simply grouping petitions together without the structure of decision makers or objectives.
 
 Within the API, both Efforts and Landing Pages use the `efforts` URLs.
 

--- a/source/includes/authenticated_api/_petitions.md.erb
+++ b/source/includes/authenticated_api/_petitions.md.erb
@@ -298,7 +298,7 @@ Create a new petition.
 If a `creator` is specified, that user will become the petition's leader, and will receive an email asking them to confirm that they are leading the petition.
 Once the leader confirms, the petition will work the same way as a petition created via the web UI.
 The URL in the response is the public petition page where supporters can sign the petition.
-To update a petition after creation, use the returned `slug` with the Update endpoint described below.
+To update a petition after creation, use the returned `slug` with the <a href="#authenticated-rest-api-petitions-update">Petition Update</a> endpoint.
 
 The request body should be a JSON block containing one `"petition"` object, which can have the following properties:
 
@@ -333,6 +333,7 @@ why | String | Text explaining why the petition is important | yes
 
 <div></div>
 
+<a name="authenticated-rest-api-petitions-update"></a>
 ### Update
 
 > PUT request body

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -28,6 +28,7 @@ includes:
   - authenticated_api/members.md.erb
   - authenticated_api/petitions.md.erb
   - authenticated_api/signatures.md.erb
+  - authenticated_api/efforts.md.erb
   - authenticated_api/partnerships
   - authenticated_api/events.md.erb
   - authenticated_api/attendees.md.erb


### PR DESCRIPTION
Documents the endpoint added in https://github.com/controlshift/agra/pull/6793

We didn't have any existing discussion of efforts in our authenticated API docs, so this also adds some intro text about them.
![image](https://user-images.githubusercontent.com/1977279/180506442-4d8e2171-14dc-4169-97ab-3f5d8a05f38d.png)

Q: Can we DRY the list of fields?
A: Enough of them have subtle differences in the effort/LP case that I think it would end up more trouble than it's worth to try and DRY, because we'd need a bunch of conditionals. I'm open to convincing, though.