### PR TITLE
Clearer instructions for API image update endpoints

### DIFF
--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -294,6 +294,8 @@ web_conference_url | String | Video call or web conference tool URL for attendee
 ### Update image
 
 The image shown on the event page can be updated by making a PUT request with the new image as the body of the request.
+The request body should be the image file itself, not a link or other metadata.
+The Content-type header should be an appropriate MIME type for the image, such as `image/jpeg`.
 
 `PUT /api/v1/events/march-against-gun-violence/images/image`
 

--- a/source/includes/authenticated_api/_petitions.md.erb
+++ b/source/includes/authenticated_api/_petitions.md.erb
@@ -426,6 +426,8 @@ why_locked | Boolean | Petition creator cannot change the "why" field
 ### Update images
 
 The image shown on the petition page can be updated by making a PUT request with the new image as the body of the request.
+The request body should be the image file itself, not a link or other metadata.
+The Content-type header should be an appropriate MIME type for the image, such as `image/jpeg`.
 
 `PUT /api/v1/petitions/no-taxes-on-tea/images/image`
 


### PR DESCRIPTION
This updates the documentation for the `/api/v1/events/foo/images/image` and `/api/v1/petitions/foo/images/image` endpoints, to be clearer about the expected format.

![image](https://user-images.githubusercontent.com/1977279/214090660-4d4cfe6b-b547-416e-9267-f8f0c2996d18.png)
![image](https://user-images.githubusercontent.com/1977279/214090743-4f0786c4-d2ed-4793-8c98-a042ac81e7c6.png)
