### PR TITLE
Add documentation for using API keys

### DIFF
--- a/source/includes/authenticated_api/_intro.md
+++ b/source/includes/authenticated_api/_intro.md
@@ -20,7 +20,7 @@ We use [OAuth2](http://oauth.net/2/) to allow organizations to securely grant ac
 
 An *API Application* must be configured within your ControlShift instance before using the API. Access is then granted to this application, and exchanged for a token which is used to authenticate your access to API endpoints.
 
-1. **Set up a new API Application** Log in as an Organisation Owner and navigate to Settings > Integrations > REST API Apps. Add a New Application. Use `urn:ietf:wg:oauth:2.0:oob` as the callback URL unless you plan to allow self-service application authorization.
+1. **Set up a new API Application** Log in as an Organisation Owner and navigate to Settings > Integrations > Legacy OAuth Apps. Add a New Application. Use `urn:ietf:wg:oauth:2.0:oob` as the callback URL unless you plan to allow self-service application authorization.
 
 2. Clone the [oauth-api-example](https://github.com/controlshift/oauth-api-example) github repo.
 

--- a/source/includes/authenticated_api/_intro.md
+++ b/source/includes/authenticated_api/_intro.md
@@ -2,11 +2,11 @@
 
 The Authenticated REST API allows customers to build applications that interact with their own data or securely grant access to third-party app developers without exposing administrative credentials. It is designed to be consumed server-side, in contrast to the JSONP API which is designed for unauthenticated javascript integrations.
 
-We support both API keys and OAuth2 for authenticating with the API. API keys are the recommended approach, because they are simpler to set up. See below for instructions on how to start using either method.
-
 If you're synchronizing data from ControlShift into another system then the Webhooks API is likely a better choice for that use case. 
 
 ## Getting Started
+We support both API keys and OAuth2 for authenticating with the API. API keys are the recommended approach, because they are simpler to set up.
+
 ### Using API Keys
 We support Bearer Authentication, using API keys that can be configured through the platform.
 

--- a/source/includes/authenticated_api/_intro.md
+++ b/source/includes/authenticated_api/_intro.md
@@ -5,7 +5,8 @@ The Authenticated REST API allows customers to build applications that interact 
 If you're synchronizing data from ControlShift into another system then the Webhooks API is likely a better choice for that use case. 
 
 ## Getting Started
-We support both API keys and OAuth2 for authenticating with the API. API keys are the recommended approach, because they are simpler to set up.
+We support both API keys and OAuth2 for authenticating with the API. API keys are the recommended approach, because they are simpler to set up and use.
+OAuth2 is supported for now, but may be deprecated in the future, so we do not recommend using it for new applications.
 
 ### Using API Keys
 We support Bearer Authentication, using API keys that can be configured through the platform.

--- a/source/includes/authenticated_api/_intro.md
+++ b/source/includes/authenticated_api/_intro.md
@@ -2,11 +2,34 @@
 
 The Authenticated REST API allows customers to build applications that interact with their own data or securely grant access to third-party app developers without exposing administrative credentials. It is designed to be consumed server-side, in contrast to the JSONP API which is designed for unauthenticated javascript integrations.
 
-We use [OAuth2](http://oauth.net/2/) to allow organizations to securely grant access to API Applications. OAuth2 is a standardized protocol that allows user credentials to be exchanged for a secret token which can then be used to access an API. There are OAuth2 implementations available for most common programming languages. You'll probably want to read some general documentation on how OAuth2 works before attempting to use this API.
+We support both API keys and OAuth2 for authenticating with the API. API keys are the recommended approach, because they are simpler to set up. See below for instructions on how to start using either method.
+
+If you're synchronizing data from ControlShift into another system then the Webhooks API is likely a better choice for that use case. 
+
+## Getting Started
+### Using API Keys
+We support Bearer Authentication, using API keys that can be configured through the platform.
+
+1. **Add a new API key** Log in as an Organisation Owner and navigate to Settings > Integrations > API Keys. Add a new API key and give it a name. Copy down the full key.
+2. Include your key in an Authorization HTTP header on your API request, like this:
+
+`curl https://demo.controlshiftlabs.com/api/v1/organisation -H "Authorization: Bearer cs_aBcDeFgHiJ0123456789kLmNoPqRsT"`
+
+### Using OAuth2
+We use [OAuth2](http://oauth.net/2/) to allow organizations to securely grant access to API Applications. OAuth2 is a standardized protocol that allows user credentials to be exchanged for a secret token which can then be used to access an API. There are OAuth2 implementations available for most common programming languages. You'll probably want to read some general documentation on how OAuth2 works before attempting to use OAuth2 to access the API.
 
 An *API Application* must be configured within your ControlShift instance before using the API. Access is then granted to this application, and exchanged for a token which is used to authenticate your access to API endpoints.
 
-If you're synchronizing data from ControlShift into another system then the Webhooks API is likely a better choice for that use case. 
+1. **Set up a new API Application** Log in as an Organisation Owner and navigate to Settings > Integrations > REST API Apps. Add a New Application. Use `urn:ietf:wg:oauth:2.0:oob` as the callback URL unless you plan to allow self-service application authorization.
+
+2. Clone the [oauth-api-example](https://github.com/controlshift/oauth-api-example) github repo.
+
+3. Follow the instructions in the README.md file to get that example working with your credentials.
+
+4. Do something similar in your actual code.
+
+**Note**: Access tokens have a 2 hours expiration, after that period you can use the old token to generate a new one.
+
 
 ## Rate Limits
 
@@ -20,15 +43,3 @@ Once the limit is reached, we will return an HTTP response with status code `429
 * `RateLimit-Limit`: returns the number of requests per minute allowed on the endpoint, values will match the ones listed above depending if you are invoking the _OAuth Token Exchange_ or one of the _Authenticated REST API_ endpoints.
 * `RateLimit-Remaining`: this header will always have `0` as value, since this response is only returned when the rate limit has been reached.
 * `RateLimit-Reset`: returns the number of seconds until the current rate limit is reset.
-
-## Quickstart Guide
-
-1. **Set up a new API Application** Log in as an Organisation Owner and navigate to Settings > Integrations > REST API Apps. Add a New Application. Use `urn:ietf:wg:oauth:2.0:oob` as the callback URL unless you plan to allow self-service application authorization.
-
-2. Clone the [oauth-api-example](https://github.com/controlshift/oauth-api-example) github repo.
-
-3. Follow the instructions in the README.md file to get that example working with your credentials.
-
-4. Do something similar in your actual code.
-
-**Note**: Access tokens have a 2 hours expiration, after that period you can use the old token to generate a new one.

--- a/source/includes/authenticated_api/_members.md.erb
+++ b/source/includes/authenticated_api/_members.md.erb
@@ -94,7 +94,7 @@ Deletes are synchronous and may take several seconds depending on how many resou
 
 Ownership of Petitions and Events created by the deleted member will be re-assigned to the user account specified in the organisation's settings.
 
-Note that if the member has a user account that is associated with one or more REST API Apps, the member cannot be deleted unless those apps are first deleted through the web UI.
+Note that if the member has a user account that is associated with one or more Legacy OAuth Apps, the member cannot be deleted unless those apps are first deleted through the web UI.
 If the member cannot be deleted for any reason, the JSON response will contain error messages explaining the problem.
 
 <div></div>
@@ -122,7 +122,7 @@ Anonymization is synchronous and may take several seconds depending on how many 
 
 Ownership of Petitions and Events created by the deleted member will be re-assigned to the user account specified in the organisation's settings.
 
-Note that if the member has a user account that is associated with one or more REST API Apps, the member cannot be anonymized unless those apps are first deleted through the web UI.
+Note that if the member has a user account that is associated with one or more Legacy OAuth Apps, the member cannot be anonymized unless those apps are first deleted through the web UI.
 If the member cannot be anonymized for any reason, the response will have a 422 Unprocessable Entity status and the JSON body will contain error messages explaining the problem.
 
 <div></div>


### PR DESCRIPTION
This updates the beginning of the Authenticated REST API section, where we talk about what the API is and how to access it.

Specifically, we're adding information about how to use API keys, and indicating that API keys are preferred over the OAuth2 method.

![image](https://github.com/controlshift/slate/assets/1977279/de65e86a-eb6c-427b-878d-2885b5cf37ef)

Also: Everywhere we were referring to the "REST API Apps" section of Settings > Integrations, we now say "Legacy OAuth Apps", to reflect the new name in the app.

This should be merged and deployed _after_ https://github.com/controlshift/agra/pull/9881, because it describes features that are added in that PR.