### PR TITLE
Remove references to deleted JSON endpoint for logged-in user data

### DIFF
--- a/source/includes/json/_intro.md
+++ b/source/includes/json/_intro.md
@@ -1,12 +1,11 @@
 # JSON API Endpoints
 
-The JSONP API is a simple way to embed ControlShift petition content in external sites. It's intended for use by a front-end developer embed content on web pages outside of the platform.  For example, a developer could:
+The JSONP API is a simple way to embed ControlShift petition content in external sites. It's intended for use by a front-end developer to embed content on web pages outside of the platform.  For example, a developer could:
 
 * Show petitions
 * Allow a user to search for near by petitions
 * List petition categories
 * Show petitions within an effort
-* If a site visitor is logged in, show a users past actions and created petitions
 
 Many of the endpoints can be consumed as JSONP instead of JSON by adding callback or variable parameters to the URLs.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -45,7 +45,7 @@ Welcome to the [ControlShift Labs](http://www.controlshiftlabs.com/) Developer d
 
 We offer several APIs to customers to cover different integration use cases.
 
-- __JSONP API__ Unauthenticated API designed to be consumed by javascript clients written by front-end engineers. Quickly display public information about petitions, efforts, and users on external sites.
+- __JSONP API__ Unauthenticated API designed to be consumed by javascript clients written by front-end engineers. Quickly display public information about petitions, efforts, and events on external sites.
 
 - __Webhooks__ Get notified when changes happen so external systems can react.
 


### PR DESCRIPTION
Once upon a time, we had a public JSON endpoint that tried to show data for the logged-in user. We deleted this endpoint a while ago, because in a world with modern protections against CSRF, it no longer worked. This PR removes references to that endpoint's functionality from the docs.