### PR TITLE
Doc improvements

### DIFF
--- a/source/includes/authenticated_api/_intro.md
+++ b/source/includes/authenticated_api/_intro.md
@@ -2,11 +2,15 @@
 
 The Authenticated REST API allows customers to build applications that interact with their own data or securely grant access to third-party app developers without exposing administrative credentials. It is designed to be consumed server-side, in contrast to the JSONP API which is designed for unauthenticated javascript integrations.
 
-If you're synchronizing data from ControlShift into another system then the Webhooks API is likely a better choice for that use case. 
+If you're synchronizing data from ControlShift into another system then the Webhooks API is likely a better choice for that use case.
 
 ## Getting Started
 We support both API keys and OAuth2 for authenticating with the API. API keys are the recommended approach, because they are simpler to set up and use.
 OAuth2 is supported for now, but may be deprecated in the future, so we do not recommend using it for new applications.
+
+### HTTP Requests Format
+
+The Authenticated REST API expects payloads in JSON format when submitting `POST` and `PUT` requests. Additionally, all responses will also be returned in this format. To ensure compatibility, the requests made to these endpoints should include the [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) and [`Content-Type`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) headers with the value `application/json`.
 
 ### Using API Keys
 We support Bearer Authentication, using API keys that can be configured through the platform.

--- a/source/includes/authenticated_api/_members.md.erb
+++ b/source/includes/authenticated_api/_members.md.erb
@@ -118,12 +118,11 @@ Anonymizes the member with specified id. This permanently deletes the member and
 
 `POST /api/v1/members/123/anonymize`
 
-Anonymization is synchronous and may take several seconds depending on how many resources are owned by the member.
+Anonymization is an asynchronous process which can take some time to complete depending on how many resources are owned by the member. If the anonymization process is correctly triggered by the API request, the HTTP response will have a `202 Accepted` status code and will not include any payload. If the member instead, cannot be anonymized for any reason, the response will have a `422 Unprocessable Entity` status and the JSON body will contain error messages explaining the problem.
 
 Ownership of Petitions and Events created by the deleted member will be re-assigned to the user account specified in the organisation's settings.
 
 Note that if the member has a user account that is associated with one or more Legacy OAuth Apps, the member cannot be anonymized unless those apps are first deleted through the web UI.
-If the member cannot be anonymized for any reason, the response will have a 422 Unprocessable Entity status and the JSON body will contain error messages explaining the problem.
 
 <div></div>
 


### PR DESCRIPTION
This PR include the following updates:

- A note mentioning the expected request's and response's JSON format, with the required 'Accept` and `Content-Type` headers
- An update on the member anonymization endpoint, explaining that the process is async and a note on the possible response status codes.

![image](https://github.com/controlshift/slate/assets/134911/47353172-5c02-4d51-99d9-db87635f0d67)

![image](https://github.com/controlshift/slate/assets/134911/f04d1036-8cfc-4721-b012-8ecae5f5b9e3)
