### PR TITLE
Updated references to event's location venue to use location_venue instead

### DIFF
--- a/source/includes/authenticated_api/_calendars.md.erb
+++ b/source/includes/authenticated_api/_calendars.md.erb
@@ -33,13 +33,13 @@ the calendar `slug` is `day-of-action-for-justice`.
 
 ### List Events
 
-List the events that are part of a Calendar. 
+List the events that are part of a Calendar.
 
 This is a paginated response. You can advance to the next page using the page parameter, which accepts a page number integer.
-By default the first page is returned. 
+By default the first page is returned.
 
 Hash     | Description
---------- | ------- 
+--------- | -------
 meta      | pagination information
 calendar  | basic information about the calendar
 events | an array of event results
@@ -64,7 +64,6 @@ events | an array of event results
     },
     "host_address": "Congressional Office, 6724-A Page Ave., St. Louis, MO 63133",
     "location": {
-      "venue": "Community Center",
       "street_number": "123",
       "street": "Main Street",
       "locality": "Kansas City",
@@ -72,6 +71,7 @@ events | an array of event results
       "postal_code": "12345",
       "country": "US"
     },
+    "location_venue": "Community Center",
     "extra_location_info": "We'll be in the multi-purpose room on the first floor.",
     "event_type": {
       "id": 12
@@ -113,10 +113,10 @@ events | an array of event results
       "query": "Community Center, 123 Main Street, Kansas City, KS 12345, US",
       "street": "Main Street",
       "street_number": "123",
-      "venue": "Community Center",
       "created_at": "2025-05-23T21:32Z",
       "extra_location_info": "We'll be in the multi-purpose room on the first floor."
     },
+    "location_venue": "Community Center",
     "event_type": {
       "name": "Movie Screening"
     },

--- a/source/includes/authenticated_api/_event_create.md.erb
+++ b/source/includes/authenticated_api/_event_create.md.erb
@@ -24,6 +24,7 @@ host | User block ([see above](#json-type-user)) | User who will host the event.
 labels | List of Strings | Labels that should be applied to the new event. Any labels that do not already exist will be created | no
 locale | String | The ISO 639-1 two-letter code for the language the event content is in. Must be one of the languages supported by ControlShift. | no; defaults to organisation's default language
 location | Location block ([see above](#json-type-location)) | Information about either the exact location of an in-person event, or the location a virtual event is relevant to. May be omitted entirely for a virtual event that doesn't have a specific audience location. If latitude and longitude are included, we’ll use them. Otherwise, we’ll geocode the fields provided. | only for in-person events
+location_venue | String | Venue name. Only relevant for in-person events | no
 max_attendees_count | Integer | Maximum number of attendees allowed | no
 partnership[slug] | String | Unique identifier for an existing partnership this event should be associated with | no
 region[slug] | String | Unique identifier for an existing region this event should be associated with | no

--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -29,7 +29,6 @@ Events represent real-world or virtual meetings that members can RSVP to. RSVP r
         "query": "wizard room",
         "latitude": "42.3376368",
         "longitude": "-70.99304",
-        "venue": "The Wizard's Throne Room",
         "street_number": "",
         "street": "",
         "region": "MA",
@@ -37,6 +36,7 @@ Events represent real-world or virtual meetings that members can RSVP to. RSVP r
         "country": "US",
         "created_at": "2017-11-16T22:38:29Z"
       },
+      "location_venue": "The Wizard's Throne Room",
       "shifts": [
         {
           "id": "103",
@@ -103,7 +103,6 @@ Returns a paginated list of all events, including ones that are unlaunched or ot
       "query": "wizard room",
       "latitude": "42.3376368",
       "longitude": "-70.99304",
-      "venue": "The Wizard's Throne Room",
       "street_number": "",
       "street": "",
       "region": "MA",
@@ -111,6 +110,7 @@ Returns a paginated list of all events, including ones that are unlaunched or ot
       "country": "US",
       "created_at": "2017-11-16T22:38:29Z"
     },
+    "location_venue": "The Wizard's Throne Room",
     "mentor": {
       "member_id": 456,
       "full_name": "Glinda the Good",
@@ -154,7 +154,6 @@ the event `slug` is `chapter-meeting-1`.
       "email": "gabrielle.giffords@example.com"
     },
     "location": {
-      "venue": "City Park",
       "street_number": "123",
       "street": "Main Street",
       "locality": "Kansas City",
@@ -162,6 +161,7 @@ the event `slug` is `chapter-meeting-1`.
       "postal_code": "12345",
       "country": "US"
     },
+    "location_venue": "City Park",
     "event_type": {
       "id": 12
     },
@@ -209,10 +209,10 @@ the event `slug` is `chapter-meeting-1`.
       "query": "City Park, 123 Main Street, Kansas City, KS 12345, US",
       "street": "Main Street",
       "street_number": "123",
-      "venue": "City Park",
       "created_at": "2025-05-23T21:32Z",
       "extra_location_info": null
     },
+    "location_venue": "City Park",
     "event_type": {
       "name": "Protest"
     },
@@ -283,6 +283,7 @@ forum_enabled | Boolean | Enables or disables the discussion forum feature for t
 hidden_address | Boolean | Indicates that the event's address is private. The city/locality will be shown on the web, but the full address will only be provided to members who RSVP to the event.
 hide_recent_attendees | Boolean | Do not display the names of people who recently RSVPed in the post-RSVP sharing prompt.
 host_address | String | The mailing address of the event host. May be used to mail event materials.
+location_venue | String | Venue name. Only relevant for in-person events.
 max_attendees_count | Integer | Limit on how many people, besides the host, may sign up for this event. Set to `null` for no limit.
 redirect_to | String | If set, visitors to the event page will be redirected to this URL
 sharing_disabled | Boolean | Turns off the social sharing prompts for the event

--- a/source/includes/authenticated_api/_json_type_location.md
+++ b/source/includes/authenticated_api/_json_type_location.md
@@ -12,6 +12,5 @@ postal_code | String | Postcode / ZIP code
 region | String | State/province/etc.
 street | String | Street name
 street_number | String | Street number (e.g. "123" in "123 Main Street")
-venue | String | Venue name (only for events)
 
 If the block does not include latitude and longitude, it must include country and at least one of locality, region, or postal code, so that we can geocode the location.


### PR DESCRIPTION
:canned_food: Companion PR for https://github.com/controlshift/agra/pull/10372.

We'll keep returning and supporting the old `location.venue` field, but there's no mention for them on docs to avoid people from using the deprecated fields.