### PR TITLE
Indicate that CORS is supported on 11 more endpoints

### DIFF
--- a/source/includes/json/_calendar.md
+++ b/source/includes/json/_calendar.md
@@ -37,7 +37,7 @@ This retrieves a JSON object representing a calendar.
 
 Where slug is the slug of the calendar you're retrieving. 
 
-- &times; CORS not supported
+- &check; CORS supported
 - &check; JSONP supported
 
 <div></div>

--- a/source/includes/json/_categories_list.md
+++ b/source/includes/json/_categories_list.md
@@ -45,7 +45,7 @@ This retrieves a JSON array of category objects.
 
 `GET https://demo.controlshiftlabs.com/categories.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &check; JSONP supported
 
 #### Working Example

--- a/source/includes/json/_category_petitions.md
+++ b/source/includes/json/_category_petitions.md
@@ -150,7 +150,7 @@ This retrieves a paginated list of petitions in a category.
 
 `GET https://demo.controlshiftlabs.com/categories/<category slug>.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &check; JSONP supported
 
 #### Query Parameters

--- a/source/includes/json/_effort_petitions.md
+++ b/source/includes/json/_effort_petitions.md
@@ -137,7 +137,7 @@ Additionally, successful petitions will have the `successful` attribute set to `
 
 `GET https://demo.controlshiftlabs.com/efforts/<effort slug>.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &check; JSONP supported
 
 Parameter | Default | Description

--- a/source/includes/json/_effort_petitions_near.md
+++ b/source/includes/json/_effort_petitions_near.md
@@ -57,7 +57,7 @@ Depending on how the effort is configured, you can search either by location, or
 
 `GET https://demo.controlshiftlabs.com/efforts/<effort slug>/lookup/query.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &check; JSONP supported
 
 #### Query Parameters

--- a/source/includes/json/_featured_petitions.md
+++ b/source/includes/json/_featured_petitions.md
@@ -155,7 +155,7 @@ This retrieves a JSON object compliant with the [JSON API](http://jsonapi.org/) 
 
 `GET https://demo.controlshiftlabs.com/petitions/featured.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &check; JSONP supported
 
 #### Query Parameters

--- a/source/includes/json/_local_details.md
+++ b/source/includes/json/_local_details.md
@@ -54,7 +54,7 @@ It can be used alongside the `/api/local/points` endpoint; the criteria for incl
 
 `GET https://demo.controlshiftlabs.com/api/local.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &times; JSONP not supported
 
 #### Query Parameters

--- a/source/includes/json/_local_points.md
+++ b/source/includes/json/_local_points.md
@@ -43,7 +43,7 @@ This JSON endpoint returns a complete list of latitude/longitude coordinates for
 
 `GET https://demo.controlshiftlabs.com/api/local/points.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &times; JSONP not supported
 
 <div></div>

--- a/source/includes/json/_partnership_petitions.md
+++ b/source/includes/json/_partnership_petitions.md
@@ -151,7 +151,7 @@ This retrieves a paginated list of petitions in a partnership.
 
 `GET https://demo.controlshiftlabs.com/partnerships/<partnership slug>/petitions.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &check; JSONP supported
 
 #### Query Parameters

--- a/source/includes/json/_petitions_search.md
+++ b/source/includes/json/_petitions_search.md
@@ -126,7 +126,7 @@ This JSON endpoint allows you to build an interface where users can search throu
 
 `GET https://demo.controlshiftlabs.com/petitions/search.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &check; JSONP supported
 
 #### Query Parameters

--- a/source/includes/json/_single_petition.md
+++ b/source/includes/json/_single_petition.md
@@ -71,7 +71,7 @@ This retrieves a single petition object.
 
 `GET https://demo.controlshiftlabs.com/petitions/<slug>.json`
 
-- &times; CORS not supported
+- &check; CORS supported
 - &check; JSONP supported
 
 #### Query Parameters


### PR DESCRIPTION
This updates the documentation for 11 public JSON API endpoints to indicate that CORS is now supported.

![image](https://github.com/user-attachments/assets/6d7bc072-390b-4766-be2d-82615b76b288)
