### PR TITLE
Improve documentation for "Local Map" public JSON API endpoints

### DIFF
--- a/source/includes/json/_local.md.erb
+++ b/source/includes/json/_local.md.erb
@@ -1,4 +1,18 @@
 ## Local Map
 
+The Local Map API endpoints are primarily used to power the
+<a href="https://demo.controlshiftlabs.com/local">local map</a>
+and embedded maps, but they can also be called independently,
+for example if you want to include the data on a different map.
+
+These endpoints include information on events created through ControlShift,
+events imported into ControlShift from external systems (a.k.a. "external events"),
+and ControlShift groups.
+
+Events and groups are only included if they are visible to the public.
+For events created in ControlShift, that means that they must be moderated as Good, not hidden, and not cancelled.
+External events are always visible to the public.
+For groups, they must have at least one member or organiser, and not be archived or unlisted.
+
 <%= partial "includes/json/local_points.md" %>
 <%= partial "includes/json/local_details.md" %>

--- a/source/includes/json/_local_details.md
+++ b/source/includes/json/_local_details.md
@@ -1,18 +1,6 @@
 ### Get organizing locations: details
 
-```js
-$(document).ready(function(){
-  $.ajax({
-    url: 'https://demo.controlshiftlabs.com/api/local.json?page=1&per_page=3',
-    dataType: 'jsonp',
-  })
-  .done(function(data) {
-    console.log(data);
-  });
-});
-```
-
-> The above code would retrieve one page of location data and log it to the js console. The JSON would be structured like this:
+> Example response
 
 ```json
 {

--- a/source/includes/json/_local_details.md
+++ b/source/includes/json/_local_details.md
@@ -59,7 +59,7 @@ filter[geography_slugs]  | null (no filter)       | Alternative way of filtering
 filter[labels]           | null (no filter)       | List of label IDs. If specified, only events/groups with at least one of those labels will be returned.
 filter[location]         | null                   | Searched location query. Should be a string such as "New York" or "90210".
 filter[regions]          | null (no filter)       | List of region IDs. If specified, only events/groups assigned to those regions will be returned.
-filter[start_date_range] | null (no filter)       | JSON object with a `start_date` and `end_date` representing a range of time. Events will only be returned if their start times are within the range, but the returned groups will not be affected.
+filter[start_date_range] | JSON object with a `start_date` and `end_date`, each in ISO-8601 string format, representing a range of time. Events will only be returned if their start times are within the range, but the returned groups will not be affected.
 filter[types]            | null (no filter)       | List of types of results to return. Should contain at least one of `event` or `group`.
 page                     | 1                      | Which page of results to fetch
 per_page                 | 10                     | How many results, maximum, should be included on each page

--- a/source/includes/json/_local_details.md
+++ b/source/includes/json/_local_details.md
@@ -59,9 +59,23 @@ It can be used alongside the `/api/local/points` endpoint; the criteria for incl
 
 #### Query Parameters
 
-Parameter | Default | Description
---------- | ------- | -----------
-page      | 1       | (optional) Which page of results to fetch
-per_page  | 10      | (optional) How many results, maximum, should be included on each page
+All parameters are optional.
+
+Parameter                | Default                | Description
+---------                | -------                | -----------
+filter[boundary_box]     | null                   | If there is a location filter, bounding box to use for geocoding the location query.
+filter[calendars]        | null (no filter)       | List of calendar slugs. If specified, only events in those calendars will be returned.
+filter[event_types]      | null (no filter)       | List of event type IDs. If specified, only events of those types will be returned.
+filter[geographies]      | null (no filter)       | List of geographic shape IDs. If specified, only events/groups whose locations fall within those geographies will be returned.
+filter[geography_slugs]  | null (no filter)       | Alternative way of filtering by geographic shapes. Works like `filter[geographies]`, but accepts a list of geography slugs instead of a list of geography IDs.
+filter[labels]           | null (no filter)       | List of label IDs. If specified, only events/groups with at least one of those labels will be returned.
+filter[location]         | null                   | Searched location query. Should be a string such as "New York" or "90210".
+filter[regions]          | null (no filter)       | List of region IDs. If specified, only events/groups assigned to those regions will be returned.
+filter[start_date_range] | null (no filter)       | JSON object with a `start_date` and `end_date` representing a range of time. Events will only be returned if their start times are within the range, but the returned groups will not be affected.
+filter[types]            | null (no filter)       | List of types of results to return. Should contain at least one of `event` or `group`.
+page                     | 1                      | Which page of results to fetch
+per_page                 | 10                     | How many results, maximum, should be included on each page
+search_strategy          | distance_from_location | When there is a location filter, determines which results match: `distance_from_location` finds all points within a certain radius, vs. `geography_for_location` finds all geographic shapes that contain the searched location
+user_country             | null                   | When there is a location filter, in which country should the location query be interpreted?
 
 <div></div>

--- a/source/includes/json/_local_points.md
+++ b/source/includes/json/_local_points.md
@@ -1,18 +1,6 @@
 ### Get organizing locations: points
 
-```js
-$(document).ready(function(){
-  $.ajax({
-    url: 'https://demo.controlshiftlabs.com/api/local/points.json',
-    dataType: 'jsonp',
-  })
-  .done(function(data) {
-    console.log(data);
-  });
-});
-```
-
-> The above code would retrieve point locations and log them to the js console. The JSON would be structured like this:
+> Example response
 
 ```json
 [

--- a/source/includes/json/_local_points.md
+++ b/source/includes/json/_local_points.md
@@ -46,4 +46,19 @@ This JSON endpoint returns a complete list of latitude/longitude coordinates for
 - &check; CORS supported
 - &times; JSONP not supported
 
+#### Query Parameters
+
+All parameters are optional and default to null (no filter).
+
+Parameter         | Description
+---------         | -----------
+filter[calendars] | List of calendar slugs. If specified, only events in those calendars will be returned.
+filter[event_types] | List of event type IDs. If specified, only events of those types will be returned.
+filter[geographies] | List of geographic shape IDs. If specified, only events/groups whose locations fall within those geographies will be returned.
+filter[geography_slugs] | Alternative way of filtering by geographic shapes. Works like `filter[geographies]`, but accepts a list of geography slugs instead of a list of geography IDs.
+filter[labels] | List of label IDs. If specified, only events/groups with at least one of those labels will be returned.
+filter[regions] | List of region IDs. If specified, only events/groups assigned to those regions will be returned.
+filter[start_date_range] | JSON object with a `start_date` and `end_date` representing a range of time. Events will only be returned if their start times are within the range, but the returned groups will not be affected.
+filter[types] | List of types of results to return. Should contain at least one of `event` or `group`.
+
 <div></div>

--- a/source/includes/json/_local_points.md
+++ b/source/includes/json/_local_points.md
@@ -46,7 +46,7 @@ filter[geographies]      | List of geographic shape IDs. If specified, only even
 filter[geography_slugs]  | Alternative way of filtering by geographic shapes. Works like `filter[geographies]`, but accepts a list of geography slugs instead of a list of geography IDs.
 filter[labels]           | List of label IDs. If specified, only events/groups with at least one of those labels will be returned.
 filter[regions]          | List of region IDs. If specified, only events/groups assigned to those regions will be returned.
-filter[start_date_range] | JSON object with a `start_date` and `end_date` representing a range of time. Events will only be returned if their start times are within the range, but the returned groups will not be affected.
+filter[start_date_range] | JSON object with a `start_date` and `end_date`, each in ISO-8601 string format, representing a range of time. Events will only be returned if their start times are within the range, but the returned groups will not be affected.
 filter[types]            | List of types of results to return. Should contain at least one of `event` or `group`.
 
 <div></div>

--- a/source/includes/json/_local_points.md
+++ b/source/includes/json/_local_points.md
@@ -38,15 +38,15 @@ This JSON endpoint returns a complete list of latitude/longitude coordinates for
 
 All parameters are optional and default to null (no filter).
 
-Parameter         | Description
----------         | -----------
-filter[calendars] | List of calendar slugs. If specified, only events in those calendars will be returned.
-filter[event_types] | List of event type IDs. If specified, only events of those types will be returned.
-filter[geographies] | List of geographic shape IDs. If specified, only events/groups whose locations fall within those geographies will be returned.
-filter[geography_slugs] | Alternative way of filtering by geographic shapes. Works like `filter[geographies]`, but accepts a list of geography slugs instead of a list of geography IDs.
-filter[labels] | List of label IDs. If specified, only events/groups with at least one of those labels will be returned.
-filter[regions] | List of region IDs. If specified, only events/groups assigned to those regions will be returned.
+Parameter                | Description
+---------                | -----------
+filter[calendars]        | List of calendar slugs. If specified, only events in those calendars will be returned.
+filter[event_types]      | List of event type IDs. If specified, only events of those types will be returned.
+filter[geographies]      | List of geographic shape IDs. If specified, only events/groups whose locations fall within those geographies will be returned.
+filter[geography_slugs]  | Alternative way of filtering by geographic shapes. Works like `filter[geographies]`, but accepts a list of geography slugs instead of a list of geography IDs.
+filter[labels]           | List of label IDs. If specified, only events/groups with at least one of those labels will be returned.
+filter[regions]          | List of region IDs. If specified, only events/groups assigned to those regions will be returned.
 filter[start_date_range] | JSON object with a `start_date` and `end_date` representing a range of time. Events will only be returned if their start times are within the range, but the returned groups will not be affected.
-filter[types] | List of types of results to return. Should contain at least one of `event` or `group`.
+filter[types]            | List of types of results to return. Should contain at least one of `event` or `group`.
 
 <div></div>


### PR DESCRIPTION
This makes several improvements to the documentation for the [Local Map](https://developers.controlshiftlabs.com/#json-api-endpoints-local-map) JSON API endpoints (`/api/local/points.json` and `/api/local.json`):

- Add intro text explaining what these endpoints are for and what data is returned
- Remove examples of calling these endpoints via JSONP, since they do not support JSONP
- Add documentation on all the parameters that are supported

![image](https://github.com/user-attachments/assets/f2ebddf2-e264-4c61-ac4f-8854f53128d7)
