### PR TITLE
Include host in authenticated API responses for events

### DIFF
--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -27,6 +27,13 @@ The authenticated REST API endpoints for events only deal with events created in
       "host_address": null,
       "max_attendees_count": null,
       "external_id": "control-shift-deliver-the-petition-to-the-wizard",
+      "host": {
+        "member_id": 123,
+        "full_name": "Dorothy of Kansas",
+        "email": "dorothy@example.com",
+        "phone_number": "555-555-5555",
+        "postcode": "66012"
+      },
       "location": {
         "query": "wizard room",
         "latitude": "42.3376368",
@@ -103,6 +110,13 @@ The response includes all the same data as the single-event endpoint for each ev
     "host_address": null,
     "max_attendees_count": null,
     "external_id": "control-shift-deliver-the-petition-to-the-wizard",
+    "host": {
+      "member_id": 123,
+      "full_name": "Dorothy of Kansas",
+      "email": "dorothy@example.com",
+      "phone_number": "555-555-5555",
+      "postcode": "66012"
+    },
     "location": {
       "query": "wizard room",
       "latitude": "42.3376368",
@@ -203,6 +217,13 @@ the event `slug` is `chapter-meeting-1`.
     "locale": "en-US",
     "host_address": null,
     "max_attendees_count": null,
+    "host": {
+      "member_id": 234,
+      "full_name": "Gabrielle Giffords",
+      "email": "gabrielle.giffords@example.com",
+      "phone_number": null,
+      "postcode": null
+    },
     "location": {
       "latitude": 39.168100,
       "longitude": -94.776063,


### PR DESCRIPTION
We recently added host information to authenticated REST API responses about events. This updates the documentation to match, by including the `host` block in the example responses from the List, Show, and Create endpoints.

![image](https://github.com/user-attachments/assets/3e1249db-1923-4eca-a26f-628faa4b37bc)
![image](https://github.com/user-attachments/assets/5f300fb7-6b40-4337-a5dd-c234e7cc4130)
