### PR TITLE
Add disable_rsvp_form field to authenticated API endpoints for events

### DIFF
--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -75,7 +75,8 @@ The authenticated REST API endpoints for events only deal with events created in
       "twitter_share_title": "Deliver the Petition to the Wizard",
       "web_share_api_share_message": "Check out this event in the Emerald City",
       "whatsapp_share_message": "I'm attending this event to deliver the petition. Join me!",
-      "share_by_email_body": "I'm attending this event and thought you might be interested. Will you join me?"
+      "share_by_email_body": "I'm attending this event and thought you might be interested. Will you join me?",
+      "disable_rsvp_form": false
     },
     ...
   ],
@@ -162,7 +163,8 @@ The response includes all the same data as the single-event endpoint for each ev
     "twitter_share_title": "Deliver the Petition to the Wizard",
     "web_share_api_share_message": "Check out this event in the Emerald City",
     "whatsapp_share_message": "I'm attending this event to deliver the petition. Join me!",
-    "share_by_email_body": "I'm attending this event and thought you might be interested. Will you join me?"
+    "share_by_email_body": "I'm attending this event and thought you might be interested. Will you join me?",
+    "disable_rsvp_form": false
   }
 }
 ```
@@ -293,7 +295,8 @@ the event `slug` is `chapter-meeting-1`.
     "twitter_share_title": null,
     "web_share_api_share_message": null,
     "whatsapp_share_message": null,
-    "share_by_email_body": null
+    "share_by_email_body": null,
+    "disable_rsvp_form": null
   }
 }
 ```

--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -296,7 +296,7 @@ the event `slug` is `chapter-meeting-1`.
     "web_share_api_share_message": null,
     "whatsapp_share_message": null,
     "share_by_email_body": null,
-    "disable_rsvp_form": null
+    "disable_rsvp_form": false
   }
 }
 ```

--- a/source/includes/authenticated_api/_events.md.erb
+++ b/source/includes/authenticated_api/_events.md.erb
@@ -336,6 +336,7 @@ Field | Type | Description
 bluesky_share_message | String | Custom message used when sharing the event on Bluesky
 campaigner_contactable | Boolean | Whether members of the public can contact the event host via the public event page
 description | String | Description of the event
+disable_rsvp_form | Boolean | Prevents new RSVPs via the event page, by replacing the RSVP form with a message that RSVPs are closed
 event_host_name_override | String | Name to display for the event host on the event page. Set to `null` to use the name from the event host's user account.
 extra_location_info | String | Additional non-address information about the event's location, e.g. "7th floor" or "Park in the back parking lot"
 facebook_share_description | String | Custom description used when sharing the event on Facebook


### PR DESCRIPTION
This updates the Authenticated REST API documentation for the Update Event endpoint to add `disable_rsvp_form` to the list of fields that can be updated.
<img width="783" height="125" alt="image" src="https://github.com/user-attachments/assets/f80a6a24-5f44-41cb-a6c5-e9ee3d866ab4" />

Also updates example JSON responses from the REST API to include the `disable_rsvp_form` field for events.